### PR TITLE
notifications endpoint looks like original UP content notifications

### DIFF
--- a/app.go
+++ b/app.go
@@ -82,12 +82,6 @@ func main() {
 		Desc:   "the nr of recent notifications to be saved and returned on the /notifications endpoint",
 		EnvVar: "NOTIFICATIONS_CAPACITY",
 	})
-	apiUrlPrefix := app.String(cli.StringOpt{
-		Name:   "apiUrlPrefix",
-		Value:  "http://localhost:8080",
-		Desc:   "the prefix of the url for /content/notifications e.g. https://api.ft.com",
-		EnvVar: "API_URL_PREFIX",
-	})
 	app.Action = func() {
 		dispatcher := newDispatcher()
 		go dispatcher.distributeEvents()
@@ -103,7 +97,7 @@ func main() {
 		infoLogger.Printf("Config: [\n\tconsumerAddrs: [%v]\n\tconsumerGroupID: [%v]\n\ttopic: [%v]\n\tconsumerAutoCommitEnable: [%v]\n\tapiBaseURL: [%v]\n\tnotifications_capacity: [%v]\n]", *consumerAddrs, *consumerGroupID, *topic, *consumerAutoCommitEnable, *apiBaseURL, *nCap)
 
 		notificationsCache := newCircularBuffer(*nCap)
-		h := handler{dispatcher, notificationsCache, *apiUrlPrefix}
+		h := handler{dispatcher, notificationsCache, *apiBaseURL}
 		hc := &healthcheck{client: http.Client{}, consumerConf: consumerConfig}
 		http.HandleFunc("/content/notifications-push", h.notificationsPush)
 		http.HandleFunc("/content/notifications", h.notifications)

--- a/app.go
+++ b/app.go
@@ -82,6 +82,12 @@ func main() {
 		Desc:   "the nr of recent notifications to be saved and returned on the /notifications endpoint",
 		EnvVar: "NOTIFICATIONS_CAPACITY",
 	})
+	apiUrlPrefix := app.String(cli.StringOpt{
+		Name:   "apiUrlPrefix",
+		Value:  "http://localhost:8080",
+		Desc:   "the prefix of the url for /content/notifications e.g. https://api.ft.com",
+		EnvVar: "API_URL_PREFIX",
+	})
 	app.Action = func() {
 		dispatcher := newDispatcher()
 		go dispatcher.distributeEvents()
@@ -97,7 +103,7 @@ func main() {
 		infoLogger.Printf("Config: [\n\tconsumerAddrs: [%v]\n\tconsumerGroupID: [%v]\n\ttopic: [%v]\n\tconsumerAutoCommitEnable: [%v]\n\tapiBaseURL: [%v]\n\tnotifications_capacity: [%v]\n]", *consumerAddrs, *consumerGroupID, *topic, *consumerAutoCommitEnable, *apiBaseURL, *nCap)
 
 		notificationsCache := newCircularBuffer(*nCap)
-		h := handler{dispatcher, notificationsCache}
+		h := handler{dispatcher, notificationsCache, *apiUrlPrefix}
 		hc := &healthcheck{client: http.Client{}, consumerConf: consumerConfig}
 		http.HandleFunc("/content/notifications-push", h.notificationsPush)
 		http.HandleFunc("/content/notifications", h.notifications)

--- a/handler.go
+++ b/handler.go
@@ -89,9 +89,9 @@ func (h handler) notifications(w http.ResponseWriter, r *http.Request) {
 		it := h.notificationsCache.items()
 		ns := make([]notificationUPP, len(it))
 		for i := range it {
-			original, ok := (it[i]).(*notificationUPP)
+			original, ok := (it[i]).(notificationUPP)
 			if ok {
-				ns[i] = *original
+				ns[i] = original
 			} else {
 				warnLogger.Printf("Couldn't cast one notification from queue buffer. Skipping: %v", it[i])
 			}

--- a/handler.go
+++ b/handler.go
@@ -14,7 +14,7 @@ const errMsgPrefix = "Serving /notifications request: [%v]"
 type handler struct {
 	dispatcher         *eventDispatcher
 	notificationsCache queue
-	apiUrlPrefix       string
+	apiBaseUrl         string
 }
 
 type stats struct {
@@ -78,10 +78,10 @@ func (h handler) notifications(w http.ResponseWriter, r *http.Request) {
 
 	if isEmpty == "true" {
 		pageUpp = notificationsPageUpp {
-			RequestUrl: h.apiUrlPrefix + r.URL.RequestURI(),
+			RequestUrl: h.apiBaseUrl + r.URL.RequestURI(),
 			Notifications: []notificationUPP{},
 			Links: []link{link{
-				Href: h.apiUrlPrefix + "/content/notifications?empty=true",
+				Href: h.apiBaseUrl + "/content/notifications?empty=true",
 				Rel: "next",
 			}},
 		}
@@ -97,10 +97,10 @@ func (h handler) notifications(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		pageUpp = notificationsPageUpp {
-			RequestUrl: h.apiUrlPrefix + r.URL.RequestURI(),
+			RequestUrl: h.apiBaseUrl + r.URL.RequestURI(),
 			Notifications: ns,
 			Links: []link{link{
-				Href: h.apiUrlPrefix + "/content/notifications?empty=true",
+				Href: h.apiBaseUrl + "/content/notifications?empty=true",
 				Rel: "next",
 			}},
 		}

--- a/handler.go
+++ b/handler.go
@@ -89,9 +89,9 @@ func (h handler) notifications(w http.ResponseWriter, r *http.Request) {
 		it := h.notificationsCache.items()
 		ns := make([]notificationUPP, len(it))
 		for i := range it {
-			original, ok := (it[i]).(notificationUPP)
+			original, ok := (it[i]).(*notificationUPP)
 			if ok {
-				ns[i] = original
+				ns[i] = *original
 			} else {
 				warnLogger.Printf("Couldn't cast one notification from queue buffer. Skipping: %v", it[i])
 			}

--- a/handler_test.go
+++ b/handler_test.go
@@ -74,15 +74,31 @@ func TestIntegration_NotificationsPushRequestsServed_NrOfClientsReflectedOnStats
 
 func TestNotifications_NotificationsInCacheMatchReponseNotifications(t *testing.T) {
 	notifications := []notificationUPP{
-		notificationUPP{PublishReference: "test1"},
-		notificationUPP{PublishReference: "test2"},
+		notificationUPP{
+			PublishReference: "test1",
+			LastModified: "2016-06-27T14:56:00.988Z",
+			notification: notification {
+				APIURL: "http://localhost:8080/content/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
+				ID:     "http://www.ft.com/thing/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
+				Type:   "http://www.ft.com/thing/ThingChangeType/UPDATE",
+			},
+		},
+		notificationUPP{
+			PublishReference: "test2",
+			LastModified: "2016-06-27T14:57:00.988Z",
+			notification: notification {
+				APIURL: "http://localhost:8080/content/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
+				ID:     "http://www.ft.com/thing/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
+				Type:   "http://www.ft.com/thing/ThingChangeType/DELETE",
+			},
+		},
 	}
 	cache := newCircularBuffer(2)
 	cache.enqueue(notifications[1])
 	cache.enqueue(notifications[0])
 
 	h := handler{notificationsCache: cache}
-	req, err := http.NewRequest("GET", "http://localhost:8080/notifications", nil)
+	req, err := http.NewRequest("GET", "http://localhost:8080/content/notifications", nil)
 	if err != nil {
 		t.Errorf("[%v]", err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -38,7 +38,7 @@ func TestGetClientAddr_XForwardedHeadersMissing(t *testing.T) {
 
 func TestIntegration_NotificationsPushRequestsServed_NrOfClientsReflectedOnStatsEndpoint(t *testing.T) {
 	//setting up test controller
-	h := handler{newDispatcher(), newCircularBuffer(1)}
+	h := handler{newDispatcher(), newCircularBuffer(1), "http://test.api.ft.com"}
 	go h.dispatcher.distributeEvents()
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -73,25 +73,24 @@ func TestIntegration_NotificationsPushRequestsServed_NrOfClientsReflectedOnStats
 }
 
 func TestNotifications_NotificationsInCacheMatchReponseNotifications(t *testing.T) {
-	notifications := []notificationUPP{
-		notificationUPP{
-			"http://localhost:8080/content/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
-			"http://www.ft.com/thing/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
-			"http://www.ft.com/thing/ThingChangeType/UPDATE",
-			"test1",
-			"2016-06-27T14:56:00.988Z",
-		},
-		notificationUPP{
-			"http://localhost:8080/content/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
-			"http://www.ft.com/thing/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
-			"http://www.ft.com/thing/ThingChangeType/DELETE",
-			"test2",
-			"2016-06-27T14:57:00.988Z",
-		},
+	not0 := notificationUPP{
+		"http://localhost:8080/content/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
+		"http://www.ft.com/thing/16ecb25e-3c63-11e6-8716-a4a71e8140b0",
+		"http://www.ft.com/thing/ThingChangeType/UPDATE",
+		"test1",
+		"2016-06-27T14:56:00.988Z",
 	}
+	not1 := notificationUPP{
+		"http://localhost:8080/content/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
+		"http://www.ft.com/thing/26ecb25e-3c63-11e6-8716-a4a71e8140b0",
+		"http://www.ft.com/thing/ThingChangeType/DELETE",
+		"test2",
+		"2016-06-27T14:57:00.988Z",
+	}
+	notificationConcreteStructs := []notificationUPP{not0, not1}
 	page := notificationsPageUpp{
 		RequestUrl:    "http://localhost:8080/content/notifications",
-		Notifications: notifications,
+		Notifications: notificationConcreteStructs,
 		Links:         []link{link{
 			Href: "http://localhost:8080/content/notifications?empty=true",
 			Rel:  "next",
@@ -100,8 +99,8 @@ func TestNotifications_NotificationsInCacheMatchReponseNotifications(t *testing.
 
 	cache := newCircularBuffer(2)
 	h := handler{notificationsCache: cache, apiBaseUrl: "http://localhost:8080"}
-	cache.enqueue(notifications[0])
-	cache.enqueue(notifications[1])
+	cache.enqueue(&not0)
+	cache.enqueue(&not1)
 	req, err := http.NewRequest("GET", "http://localhost:8080/content/notifications", nil)
 	if err != nil {
 		t.Errorf("[%v]", err)

--- a/notifications.go
+++ b/notifications.go
@@ -16,6 +16,17 @@ type notificationUPP struct {
 	PublishReference string `json:"publishReference"`
 }
 
+type link struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+type notificationsPageUpp struct {
+	RequestUrl    string            `json:"requestUrl"`
+	Notifications []notificationUPP `json:"notifications"`
+	Links         []link            `json:"links"`
+}
+
 func (nb notificationBuilder) buildNotification(cmsPubEvent cmsPublicationEvent) *notification {
 	if cmsPubEvent.UUID == "" {
 		return nil

--- a/notifications.go
+++ b/notifications.go
@@ -11,7 +11,9 @@ type notification struct {
 }
 
 type notificationUPP struct {
-	notification
+	APIURL           string `json:"apiUrl"`
+	ID               string `json:"id"`
+	Type             string `json:"type"`
 	LastModified     string `json:"lastModified"`
 	PublishReference string `json:"publishReference"`
 }
@@ -58,7 +60,9 @@ func (nb notificationBuilder) buildNotification(cmsPubEvent cmsPublicationEvent)
 
 func buildUPPNotification(n *notification, tid, lastModified string) *notificationUPP {
 	return &notificationUPP{
-		notification:     *n,
+		APIURL:           n.APIURL,
+		ID:               n.ID,
+		Type:             n.Type,
 		LastModified:     lastModified,
 		PublishReference: tid,
 	}


### PR DESCRIPTION
I’m modifying notifications-push so that it has an endpoint `/content/notifications` that is almost exactly like the original UP notifications endpoint, the format at least, exact. It doesn’t have the same pagination because after the first page, it sends to you ?empty=true, which responds with a notifications page with [] notifications. This is for PAM to be able to check upon push.. the same way as for original notif.