### PR TITLE
parse UUID from ContentURI instead of taking if directly from the message

### DIFF
--- a/consumer/consume_test.go
+++ b/consumer/consume_test.go
@@ -96,7 +96,7 @@ func TestFailsConversionToNotification(t *testing.T) {
 				"X-Request-Id": "tid_summin",
 			},
 			Body: `{
-	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah"
+	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah/55e40823-6804-4264-ac2f-b29e11bf756a" +
 	      }`,
 		},
 	}
@@ -123,7 +123,7 @@ func TestHandleMessage(t *testing.T) {
 			},
 			Body: `{
 	         "UUID": "a uuid",
-	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah"
+	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah/55e40823-6804-4264-ac2f-b29e11bf756a"
 	      }`,
 		},
 	}

--- a/consumer/mapper.go
+++ b/consumer/mapper.go
@@ -13,7 +13,7 @@ type NotificationMapper struct {
 	Resource   string
 }
 
-var UUIDRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}")
+var UUIDRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}")
 
 // MapNotification maps the given event to a new notification.
 func (n NotificationMapper) MapNotification(event PublicationEvent, transactionID string) (dispatcher.Notification, error) {

--- a/consumer/mapper.go
+++ b/consumer/mapper.go
@@ -2,6 +2,7 @@ package consumer
 
 import (
 	"errors"
+	"regexp"
 
 	"github.com/Financial-Times/notifications-push/dispatcher"
 )
@@ -12,10 +13,13 @@ type NotificationMapper struct {
 	Resource   string
 }
 
+var UUIDRegexp = regexp.MustCompile("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}")
+
 // MapNotification maps the given event to a new notification.
 func (n NotificationMapper) MapNotification(event PublicationEvent, transactionID string) (dispatcher.Notification, error) {
-	if event.UUID == "" {
-		return dispatcher.Notification{}, errors.New("CMS publication event does not contain a UUID")
+	UUID := UUIDRegexp.FindString(event.ContentURI)
+	if UUID == "" {
+		return dispatcher.Notification{}, errors.New("ContentURI does not contain a UUID")
 	}
 
 	var eventType string
@@ -27,8 +31,8 @@ func (n NotificationMapper) MapNotification(event PublicationEvent, transactionI
 
 	return dispatcher.Notification{
 		Type:             "http://www.ft.com/thing/ThingChangeType/" + eventType,
-		ID:               "http://www.ft.com/thing/" + event.UUID,
-		APIURL:           n.APIBaseURL + "/" + n.Resource + "/" + event.UUID,
+		ID:               "http://www.ft.com/thing/" + UUID,
+		APIURL:           n.APIBaseURL + "/" + n.Resource + "/" + UUID,
 		PublishReference: transactionID,
 		LastModified:     event.LastModified,
 	}, nil

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -12,8 +12,7 @@ func TestMapToUpdateNotification(t *testing.T) {
 	payload := struct{ Foo string }{"bar"}
 
 	event := PublicationEvent{
-		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8080/list/blah",
-		UUID:         uuid.NewV4().String(),
+		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + uuid.NewV4().String(),
 		LastModified: "2016-11-02T10:54:22.234Z",
 		Payload:      payload,
 	}
@@ -32,8 +31,7 @@ func TestMapToUpdateNotification(t *testing.T) {
 func TestMapToDeleteNotification(t *testing.T) {
 
 	event := PublicationEvent{
-		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8080/list/blah",
-		UUID:         uuid.NewV4().String(),
+		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8080/list/blah/" + uuid.NewV4().String(),
 		LastModified: "2016-11-02T10:54:22.234Z",
 		Payload:      "",
 	}

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -28,6 +28,27 @@ func TestMapToUpdateNotification(t *testing.T) {
 	assert.Nil(t, err, "The mapping should not return an error")
 }
 
+func TestMapToUpdateNotification_ForContentWithVersion3UUID(t *testing.T) {
+
+	payload := struct{ Foo string }{"bar"}
+
+	event := PublicationEvent{
+		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + uuid.NewV3(uuid.UUID{}, "id").String(),
+		LastModified: "2016-11-02T10:54:22.234Z",
+		Payload:      payload,
+	}
+
+	mapper := NotificationMapper{
+		APIBaseURL: "test.api.ft.com",
+		Resource:   "list",
+	}
+
+	n, err := mapper.MapNotification(event, "tid_test1")
+
+	assert.Equal(t, "http://www.ft.com/thing/ThingChangeType/UPDATE", n.Type, "It is an UPDATE notification")
+	assert.Nil(t, err, "The mapping should not return an error")
+}
+
 func TestMapToDeleteNotification(t *testing.T) {
 
 	event := PublicationEvent{

--- a/consumer/publish_event.go
+++ b/consumer/publish_event.go
@@ -32,7 +32,6 @@ func (msg NotificationQueueMessage) ToPublicationEvent() (event PublicationEvent
 
 type PublicationEvent struct {
 	ContentURI   string      `json:"contentUri"`
-	UUID         string      `json:"uuid"`
 	Payload      interface{} `json:"payload"`
 	LastModified string      `json:"lastModified"`
 }


### PR DESCRIPTION
I'm not entirely happy with this, but at least it's now consistent with the Ingester's way of parsing the  UUID. 

One less redundant field in CmsPublicationEvents, and let's review it once the mapper work is completed.

Edit/Context: the mappers, bar the list-mapper, do not put the UUID field on the msg.