### PR TITLE
Revert "Logging when closing connection"

### DIFF
--- a/resources/push.go
+++ b/resources/push.go
@@ -32,11 +32,10 @@ func Push(reg dispatcher.Registrar) func(w http.ResponseWriter, r *http.Request)
 
 		var s dispatcher.Subscriber
 
-		clientAddr := getClientAddr(r)
 		if isMonitor {
-			s = dispatcher.NewMonitorSubscriber(clientAddr)
+			s = dispatcher.NewMonitorSubscriber(getClientAddr(r))
 		} else {
-			s = dispatcher.NewStandardSubscriber(clientAddr)
+			s = dispatcher.NewStandardSubscriber(getClientAddr(r))
 		}
 
 		reg.Register(s)
@@ -60,7 +59,6 @@ func Push(reg dispatcher.Registrar) func(w http.ResponseWriter, r *http.Request)
 				flusher := w.(http.Flusher)
 				flusher.Flush()
 			case <-cn.CloseNotify():
-				log.WithField("subscriber", clientAddr).Info("Connection is being closed to subscriber")
 				return
 			}
 		}


### PR DESCRIPTION
Reverts Financial-Times/notifications-push#39
There is already logging established for when a subscriber goes away. My line was similar to a duplicate of an already existing mechanism. Revert from codebase. Release wasn't done yet just to xp, from where i'll revert as well.