### PR TITLE
Bugfix/carousel tid

### DIFF
--- a/app.go
+++ b/app.go
@@ -138,7 +138,7 @@ func main() {
 		}
 
 		queueHandler := consumer.NewMessageQueueHandler(whitelistR, mapper, dispatcher)
-		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, http.Client{})
+		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, &http.Client{})
 
 		go server(":"+strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig)
 

--- a/consumer/consume_test.go
+++ b/consumer/consume_test.go
@@ -144,7 +144,7 @@ func TestDiscardStandardCarouselPublicationEvents(t *testing.T) {
 	dispatcher := new(mocks.MockDispatcher)
 	handler := NewMessageQueueHandler(defaultWhitelist, mapper, dispatcher)
 
-	msg := []queueConsumer.Message{
+	msg1 := []queueConsumer.Message{
 		{
 			Headers: map[string]string{
 				"X-Request-Id": "tid_fzy2uqund8_carousel_1485954245",
@@ -156,7 +156,33 @@ func TestDiscardStandardCarouselPublicationEvents(t *testing.T) {
 		},
 	}
 
-	handler.HandleMessage(msg)
+	msg2 := []queueConsumer.Message{
+		{
+			Headers: map[string]string{
+				"X-Request-Id": "republish_-10bd337c-66d4-48d9-ab8a-e8441fa2ec98_carousel_1493606135",
+			},
+			Body: `{
+	         "UUID": "a uuid",
+	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah/55e40823-6804-4264-ac2f-b29e11bf756a"
+	      }`,
+		},
+	}
+
+	msg3 := []queueConsumer.Message{
+		{
+			Headers: map[string]string{
+				"X-Request-Id": "tid_ofcysuifp0_carousel_1488384556_gentx",
+			},
+			Body: `{
+	         "UUID": "a uuid",
+	         "ContentURI": "http://list-transformer-pr-uk-up.svc.ft.com:8080/lists/blah/55e40823-6804-4264-ac2f-b29e11bf756a"
+	      }`,
+		},
+	}
+	handler.HandleMessage(msg1)
+	handler.HandleMessage(msg2)
+	handler.HandleMessage(msg3)
+
 	dispatcher.AssertNotCalled(t, "Send")
 }
 

--- a/consumer/publish_event.go
+++ b/consumer/publish_event.go
@@ -24,7 +24,7 @@ func (msg NotificationQueueMessage) HasCarouselTransactionID() bool {
 	return carouselTransactionIDRegExp.MatchString(msg.TransactionID())
 }
 
-var carouselTransactionIDRegExp = regexp.MustCompile(`^(tid_[\S]+)_carousel_[\d]{10}.*$`) //`^(tid_[\S]+)_carousel_[\d]{10}.*$`
+var carouselTransactionIDRegExp = regexp.MustCompile(`^.+_carousel_[\d]{10}.*$`) //`^(tid_[\S]+)_carousel_[\d]{10}.*$`
 
 // TransactionID returns the message TID
 func (msg NotificationQueueMessage) TransactionID() string {

--- a/push_service.go
+++ b/push_service.go
@@ -13,10 +13,10 @@ import (
 
 type pushService struct {
 	dispatcher dispatcher.Dispatcher
-	consumer   queueConsumer.Consumer
+	consumer   queueConsumer.MessageConsumer
 }
 
-func newPushService(d dispatcher.Dispatcher, consumer queueConsumer.Consumer) *pushService {
+func newPushService(d dispatcher.Dispatcher, consumer queueConsumer.MessageConsumer) *pushService {
 	return &pushService{
 		dispatcher: d,
 		consumer:   consumer,


### PR DESCRIPTION
This changes exclude notifications of publication events with unconventional transactions ids generated by the publish carousel.