### PR TITLE
Add api key validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /notifications-push-client
 /.env
 *.iml
-
+vendor/*/
 /.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,31 @@
-FROM alpine:3.5
+FROM golang:1.8-alpine
 
-COPY . .git /notifications-push/
+ENV PROJECT=notifications-push
+COPY . /${PROJECT}-sources/
 
-RUN apk --update add git go libc-dev \
-  && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/notifications-push" \
-  && mkdir -p $GOPATH/src/${REPO_PATH} \
-  && mv /notifications-push/* $GOPATH/src/${REPO_PATH} \
+RUN apk --no-cache --virtual .build-dependencies add git \
+  && ORG_PATH="github.com/Financial-Times" \
+  && REPO_PATH="${ORG_PATH}/${PROJECT}" \
+  && mkdir -p $GOPATH/src/${ORG_PATH} \
+  # Linking the project sources in the GOPATH folder
+  && ln -s /${PROJECT}-sources $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
-  && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
+  && BUILDINFO_PACKAGE="${ORG_PATH}/${PROJECT}/vendor/${ORG_PATH}/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
   && REPOSITORY="repository=$(git config --get remote.origin.url)" \
   && REVISION="revision=$(git rev-parse HEAD)" \
   && BUILDER="builder=$(go version)" \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
-  && echo $LDFLAGS \
+  && echo "Build flags: $LDFLAGS" \
+  && echo "Fetching dependencies..." \
   && go get -u github.com/kardianos/govendor \
   && $GOPATH/bin/govendor sync \
   && go build -ldflags="${LDFLAGS}" \
-  && mv notifications-push /notifications-push-app \
-  && rm -rf /notifications-push \
-  && mv /notifications-push-app /notifications-push \
-  && apk del go git libc-dev \
+  && mv ${PROJECT} /${PROJECT}-app \
+  && apk del .build-dependencies \
   && rm -rf $GOPATH /var/cache/apk/*
 
-CMD [ "/notifications-push" ]
+WORKDIR /
+
+CMD [ "/notifications-push-app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apk --update add git go libc-dev \
   && BUILDER="builder=$(go version)" \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
   && echo $LDFLAGS \
-  && go get -t ./... \
+  && go get -u github.com/kardianos/govendor \
+  && $GOPATH/bin/govendor sync \
   && go build -ldflags="${LDFLAGS}" \
   && mv notifications-push /notifications-push-app \
   && rm -rf /notifications-push \

--- a/app.go
+++ b/app.go
@@ -25,8 +25,7 @@ import (
 const heartbeatPeriod = 30 * time.Second
 
 func init() {
-	f := &log.TextFormatter{
-		FullTimestamp:   true,
+	f := &log.JSONFormatter{
 		TimestampFormat: time.RFC3339Nano,
 	}
 

--- a/app.go
+++ b/app.go
@@ -78,7 +78,7 @@ func main() {
 	})
 	apiKeyValidationEndpoint := app.String(cli.StringOpt{
 		Name:   "api_key_validation_endpoint",
-		Value:  "/t800/a",
+		Value:  "t800/a",
 		Desc:   "The Mashery ApiKey validation endpoint",
 		EnvVar: "API_KEY_VALIDATION_ENDPOINT",
 	})
@@ -146,7 +146,7 @@ func main() {
 		queueHandler := consumer.NewMessageQueueHandler(whitelistR, mapper, dispatcher)
 		httpClient := &http.Client{}
 		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, httpClient)
-		masheryApiKeyValidationUrl := fmt.Sprintf("%s/%s", apiBaseURL, apiKeyValidationEndpoint)
+		masheryApiKeyValidationUrl := fmt.Sprintf("%s/%s", *apiBaseURL, *apiKeyValidationEndpoint)
 		go server(":" + strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, httpClient)
 
 		pushService := newPushService(dispatcher, consumer)

--- a/app.go
+++ b/app.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -8,9 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
 
+	"fmt"
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	queueConsumer "github.com/Financial-Times/message-queue-gonsumer/consumer"
 	"github.com/Financial-Times/notifications-push/consumer"
@@ -18,7 +19,6 @@ import (
 	"github.com/Financial-Times/notifications-push/resources"
 	"github.com/Financial-Times/service-status-go/httphandlers"
 	"github.com/jawher/mow.cli"
-	"fmt"
 	"net"
 )
 
@@ -130,7 +130,7 @@ func main() {
 		}
 
 		history := dispatcher.NewHistory(*historySize)
-		dispatcher := dispatcher.NewDispatcher(time.Duration(*delay) * time.Second, heartbeatPeriod, history)
+		dispatcher := dispatcher.NewDispatcher(time.Duration(*delay)*time.Second, heartbeatPeriod, history)
 
 		mapper := consumer.NotificationMapper{
 			Resource:   *resource,
@@ -147,7 +147,7 @@ func main() {
 		hc := getResilientClient()
 		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, hc)
 		masheryApiKeyValidationUrl := fmt.Sprintf("%s/%s", *apiBaseURL, *apiKeyValidationEndpoint)
-		go server(":" + strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, hc)
+		go server(":"+strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, hc)
 
 		pushService := newPushService(dispatcher, consumer)
 		pushService.start()

--- a/app.go
+++ b/app.go
@@ -144,10 +144,10 @@ func main() {
 		}
 
 		queueHandler := consumer.NewMessageQueueHandler(whitelistR, mapper, dispatcher)
-		hc := getResilientClient()
-		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, hc)
+		httpClient := getResilientClient()
+		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, httpClient)
 		masheryApiKeyValidationUrl := fmt.Sprintf("%s/%s", *apiBaseURL, *apiKeyValidationEndpoint)
-		go server(":"+strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, hc)
+		go server(":"+strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, httpClient)
 
 		pushService := newPushService(dispatcher, consumer)
 		pushService.start()

--- a/app.go
+++ b/app.go
@@ -144,7 +144,19 @@ func main() {
 		}
 
 		queueHandler := consumer.NewMessageQueueHandler(whitelistR, mapper, dispatcher)
-		httpClient := getResilientClient()
+
+		tr := &http.Transport{
+			MaxIdleConnsPerHost: 32,
+			Dial: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+		}
+		httpClient := &http.Client{
+			Transport: tr,
+			Timeout:   time.Duration(10 * time.Second),
+		}
+
 		consumer := queueConsumer.NewBatchedConsumer(consumerConfig, queueHandler.HandleMessage, httpClient)
 		masheryApiKeyValidationUrl := fmt.Sprintf("%s/%s", *apiBaseURL, *apiKeyValidationEndpoint)
 		go server(":"+strconv.Itoa(*port), *resource, dispatcher, history, consumerConfig, masheryApiKeyValidationUrl, httpClient)
@@ -178,19 +190,4 @@ func server(listen string, resource string, dispatcher dispatcher.Dispatcher, hi
 
 	err := http.ListenAndServe(listen, nil)
 	log.Fatal(err)
-}
-
-func getResilientClient() *http.Client {
-	tr := &http.Transport{
-		MaxIdleConnsPerHost: 32,
-		Dial: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
-	}
-	c := &http.Client{
-		Transport: tr,
-		Timeout:   time.Duration(10 * time.Second),
-	}
-	return c
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,32 +1,30 @@
 machine:
   environment:
-    GODIST: "go1.7.3.linux-amd64.tar.gz"
+    PROJECT_GOPATH: "${HOME}/.go_project"
+    PROJECT_PARENT_PATH: "${PROJECT_GOPATH}/src/github.com/${CIRCLE_PROJECT_USERNAME}"
+    PROJECT_PATH: "${PROJECT_PARENT_PATH}/${CIRCLE_PROJECT_REPONAME}"
+    GOPATH: "${HOME}/.go_workspace:${PROJECT_GOPATH}"
+
+checkout:
   post:
-    - mkdir -p download
-    - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
-    - sudo rm -rf /usr/local/go
-    - sudo tar -C /usr/local -xzf download/$GODIST
-  services:
-    - docker
+    - mkdir -p "${PROJECT_PARENT_PATH}"
+    - ln -sf "${HOME}/${CIRCLE_PROJECT_REPONAME}/" "${PROJECT_PATH}"
+
 dependencies:
   pre:
-    - go get github.com/axw/gocov/gocov; go get github.com/matm/gocov-html; go get -u github.com/jstemmer/go-junit-report
+    - go get -u github.com/kardianos/govendor
+  override:
+    - cd $PROJECT_PATH && govendor sync
+    - cd $PROJECT_PATH && go build -v
+
 test:
   pre:
-    - go get github.com/mattn/goveralls
+    - go get -u github.com/jstemmer/go-junit-report
+    - go get -u github.com/mattn/goveralls
+    - cd $PROJECT_PATH && wget https://raw.githubusercontent.com/Financial-Times/cookiecutter-upp-golang/master/coverage.sh && chmod +x coverage.sh
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/golang
-    - go test -race -v ./... | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
-    - go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/consumer.out ./consumer
-    - go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/dispatcher.out ./dispatcher
-    - go test -v -cover -race -coverprofile=$CIRCLE_ARTIFACTS/resources.out ./resources
-    - cd $CIRCLE_ARTIFACTS && sed -i '1d' *.out
-    - |
-      echo "mode: atomic" > $CIRCLE_ARTIFACTS/overall-coverage.result
-    - cd $CIRCLE_ARTIFACTS && cat *.out >> overall-coverage.result
-    - docker build --rm=false -t test/notifications-push .
-    - docker run -d -p 9200:8080 test/notifications-push; sleep 3
-    - curl --retry 10 --retry-delay 5 -v http://localhost:9200/__health
+    - cd $PROJECT_PATH && govendor test -race -v +local | go-junit-report > $CIRCLE_TEST_REPORTS/golang/junit.xml
+    - cd $PROJECT_PATH && ./coverage.sh
   post:
-    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/overall-coverage.result -service=circle-ci -repotoken=$COVERALLS_TOKEN
-    - bash <(curl -s https://codecov.io/bash)
+    - goveralls -coverprofile=$CIRCLE_ARTIFACTS/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/resources/push.go
+++ b/resources/push.go
@@ -10,6 +10,16 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+//ApiKey is provided either as a request param or as a header.
+func getApiKey(r *http.Request) string {
+	apiKey := r.Header.Get("x-api-key")
+	if apiKey != "" {
+		return apiKey
+	}
+
+	return r.URL.Query().Get("apiKey")
+}
+
 // Push handler for push subscribers
 func Push(reg dispatcher.Registrar, masheryApiKeyValidationURL string, httpClient *http.Client) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -19,7 +29,7 @@ func Push(reg dispatcher.Registrar, masheryApiKeyValidationURL string, httpClien
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("Expires", "0")
 
-		apiKey := r.Header.Get("x-api-key")
+		apiKey := getApiKey(r)
 		if isValid := validateApiKey(apiKey, masheryApiKeyValidationURL, httpClient, w); !isValid {
 			return
 		}

--- a/resources/push.go
+++ b/resources/push.go
@@ -94,7 +94,7 @@ func getClientAddr(r *http.Request) string {
 
 func validateApiKey(providedApiKey string, masheryApiKeyValidationURL string, httpClient *http.Client, w http.ResponseWriter) bool {
 	req, err := http.NewRequest("GET", masheryApiKeyValidationURL, nil)
-	req.Header.Add("x-api-key", providedApiKey)
+	req.Header.Set("x-api-key", providedApiKey)
 	if err != nil {
 		log.WithError(err).Warn("Cannot create request")
 		http.Error(w, "Invalid api key", http.StatusInternalServerError)

--- a/resources/push.go
+++ b/resources/push.go
@@ -13,18 +13,18 @@ import (
 )
 
 const (
-	ApiKeyHeaderField = "X-Api-Key"
-	ApiKeyQueryParam  = "apiKey"
+	apiKeyHeaderField = "X-Api-Key"
+	apiKeyQueryParam  = "apiKey"
 )
 
 //ApiKey is provided either as a request param or as a header.
 func getApiKey(r *http.Request) string {
-	apiKey := r.Header.Get(ApiKeyHeaderField)
+	apiKey := r.Header.Get(apiKeyHeaderField)
 	if apiKey != "" {
 		return apiKey
 	}
 
-	return r.URL.Query().Get(ApiKeyQueryParam)
+	return r.URL.Query().Get(apiKeyQueryParam)
 }
 
 // Push handler for push subscribers
@@ -97,6 +97,11 @@ func getClientAddr(r *http.Request) string {
 }
 
 func validApiKey(w http.ResponseWriter, providedApiKey string, masheryApiKeyValidationURL string, httpClient *http.Client) bool {
+	if providedApiKey == "" {
+		http.Error(w, "Empty api key", http.StatusUnauthorized)
+		return false
+	}
+
 	req, err := http.NewRequest("GET", masheryApiKeyValidationURL, nil)
 	if err != nil {
 		log.WithField("url", masheryApiKeyValidationURL).WithError(err).Error("Invalid URL for api key validation")
@@ -104,7 +109,7 @@ func validApiKey(w http.ResponseWriter, providedApiKey string, masheryApiKeyVali
 		return false
 	}
 
-	req.Header.Set(ApiKeyHeaderField, providedApiKey)
+	req.Header.Set(apiKeyHeaderField, providedApiKey)
 
 	apiKeyFirstChars := ""
 	if isApiKeyFirstFourCharsLoggable(providedApiKey) {

--- a/resources/push.go
+++ b/resources/push.go
@@ -94,12 +94,13 @@ func getClientAddr(r *http.Request) string {
 
 func validateApiKey(providedApiKey string, masheryApiKeyValidationURL string, httpClient *http.Client, w http.ResponseWriter) bool {
 	req, err := http.NewRequest("GET", masheryApiKeyValidationURL, nil)
-	req.Header.Set("x-api-key", providedApiKey)
 	if err != nil {
 		log.WithError(err).Warn("Cannot create request")
 		http.Error(w, "Invalid api key", http.StatusInternalServerError)
 		return false
 	}
+
+	req.Header.Set("x-api-key", providedApiKey)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/resources/push.go
+++ b/resources/push.go
@@ -110,11 +110,11 @@ func validApiKey(w http.ResponseWriter, providedApiKey string, masheryApiKeyVali
 	if isApiKeyFirstFourCharsLoggable(providedApiKey) {
 		apiKeyFirstChars = providedApiKey[0:3]
 	}
-	log.WithField("url", req.RequestURI).WithField("apiKeyFirstChars", apiKeyFirstChars).Info("Calling Mashery to validate api key")
+	log.WithField("url", req.URL.String()).WithField("apiKeyFirstChars", apiKeyFirstChars).Info("Calling Mashery to validate api key")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		log.WithField("url", req.RequestURI).WithError(err).Error("Cannot send request to Mashery")
+		log.WithField("url", req.URL.String()).WithError(err).Error("Cannot send request to Mashery")
 		http.Error(w, "Request to validate api key failed", http.StatusInternalServerError)
 		return false
 	}
@@ -134,7 +134,7 @@ func validApiKey(w http.ResponseWriter, providedApiKey string, masheryApiKeyVali
 		return false
 	}
 
-	log.WithError(err).Error("Received unexpected status code from Mashery: %d", respStatusCode)
+	log.WithError(err).Errorf("Received unexpected status code from Mashery: %d", respStatusCode)
 	http.Error(w, "Request to validate api key returned an unexpected response", http.StatusServiceUnavailable)
 	return false
 }

--- a/resources/push.go
+++ b/resources/push.go
@@ -28,11 +28,14 @@ func Push(reg dispatcher.Registrar, masheryApiKeyValidationURL string, httpClien
 		w.Header().Set("Connection", "keep-alive")
 		w.Header().Set("Pragma", "no-cache")
 		w.Header().Set("Expires", "0")
-
+		log.Infof("Validating api key..")
 		apiKey := getApiKey(r)
 		if isValid := validateApiKey(apiKey, masheryApiKeyValidationURL, httpClient, w); !isValid {
+			log.Infof("Provided api key is invalid")
 			return
 		}
+
+		log.Infof("Provided api key is valid")
 
 		cn, ok := w.(http.CloseNotifier)
 		if !ok {

--- a/resources/push.go
+++ b/resources/push.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/Financial-Times/notifications-push/dispatcher"
 	log "github.com/Sirupsen/logrus"
-	"io/ioutil"
 	"io"
+	"io/ioutil"
 )
 
-const(
+const (
 	ApiKeyHeaderField = "X-Api-Key"
-	ApiKeyQueryParam = "apiKey"
+	ApiKeyQueryParam  = "apiKey"
 )
 
 //ApiKey is provided either as a request param or as a header.
@@ -129,12 +129,12 @@ func validApiKey(w http.ResponseWriter, providedApiKey string, masheryApiKeyVali
 	}
 
 	if respStatusCode == http.StatusUnauthorized {
-		log.WithField("apiKeyFirstChars", apiKeyFirstChars).WithError(err).Error("Invalid api key")
+		log.WithField("apiKeyFirstChars", apiKeyFirstChars).Error("Invalid api key")
 		http.Error(w, "Invalid api key", http.StatusUnauthorized)
 		return false
 	}
 
-	log.WithError(err).Errorf("Received unexpected status code from Mashery: %d", respStatusCode)
+	log.WithField("url", req.URL.String()).Errorf("Received unexpected status code from Mashery: %d", respStatusCode)
 	http.Error(w, "Request to validate api key returned an unexpected response", http.StatusServiceUnavailable)
 	return false
 }

--- a/resources/push_test.go
+++ b/resources/push_test.go
@@ -38,7 +38,7 @@ func TestPushStandardSubscriber(t *testing.T) {
 		assert.Equal(t, "some-host", sub.Address())
 	}
 
-	Push(d)(w, req)
+	Push(d, "http://dummy.ft.com", &http.Client{})(w, req)
 
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"), "Should be SSE")
 	assert.Equal(t, "no-cache, no-store, must-revalidate", w.Header().Get("Cache-Control"))
@@ -78,7 +78,7 @@ func TestPushMonitorSubscriber(t *testing.T) {
 		assert.Equal(t, "some-host", sub.Address())
 	}
 
-	Push(d)(w, req)
+	Push(d, "http://dummy.ft.com", &http.Client{})(w, req)
 
 	assert.Equal(t, "text/event-stream", w.Header().Get("Content-Type"), "Should be SSE")
 	assert.Equal(t, "no-cache, no-store, must-revalidate", w.Header().Get("Cache-Control"))
@@ -103,7 +103,7 @@ func TestPushFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Push(d)(w, req)
+	Push(d, "http://dummy.ft.com", &http.Client{})(w, req)
 	assert.Equal(t, 500, w.Code)
 }
 

--- a/resources/validator.go
+++ b/resources/validator.go
@@ -1,0 +1,52 @@
+package resources
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func isValidApiKey(providedApiKey string, masheryApiKeyValidationURL string, httpClient *http.Client) (bool, string, int) {
+	if providedApiKey == "" {
+		return false, "Empty api key", http.StatusUnauthorized
+	}
+
+	req, err := http.NewRequest("GET", masheryApiKeyValidationURL, nil)
+	if err != nil {
+		log.WithField("url", masheryApiKeyValidationURL).WithError(err).Error("Invalid URL for api key validation")
+		return false, "Invalid URL", http.StatusInternalServerError
+	}
+
+	req.Header.Set(apiKeyHeaderField, providedApiKey)
+
+	//if the api key has more than four characters we want to log the first four
+	apiKeyFirstChars := ""
+	if len(providedApiKey) > 4 {
+		apiKeyFirstChars = providedApiKey[0:4]
+	}
+	log.WithField("url", req.URL.String()).WithField("apiKeyFirstChars", apiKeyFirstChars).Info("Calling Mashery to validate api key")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.WithField("url", req.URL.String()).WithError(err).Error("Cannot send request to Mashery")
+		return false, "Request to validate api key failed", http.StatusInternalServerError
+	}
+	defer func() {
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	respStatusCode := resp.StatusCode
+	if respStatusCode == http.StatusOK {
+		return true, "", 0
+	}
+
+	if respStatusCode == http.StatusUnauthorized {
+		log.WithField("apiKeyFirstChars", apiKeyFirstChars).Error("Invalid api key")
+		return false, "Invalid api key", http.StatusUnauthorized
+	}
+
+	log.WithField("url", req.URL.String()).Errorf("Received unexpected status code from Mashery: %d", respStatusCode)
+	return false, "Request to validate api key returned an unexpected response", http.StatusServiceUnavailable
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,97 +3,103 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "FUhczVSvt/VQAlWfzATo1YLez2E=",
+			"checksumSHA1": "4gy/7n/lgtdi5efuHXwFcIe1ZI8=",
 			"path": "github.com/Financial-Times/go-fthealth/v1a",
-			"revision": "bc27ed19189994eef0364e4a07879d5a3f3be76f",
-			"revisionTime": "2017-03-24T12:21:32Z"
+			"revision": "e7ccca038327a0091303a52445ec1f0fb66cb97b",
+			"revisionTime": "2017-05-25T09:50:41Z"
 		},
 		{
-			"checksumSHA1": "/kMYtkcxWV4dZNvJaEGkDUwt3TA=",
+			"checksumSHA1": "v+iZMRghLJr+LHe8ihEViOFE+9g=",
 			"path": "github.com/Financial-Times/message-queue-gonsumer/consumer",
-			"revision": "4e173298922ba4c10721b1b5b3e0d35be7f162e9",
-			"revisionTime": "2017-03-20T10:34:32Z"
+			"revision": "6f96a5cb1e34c4baa8bc64f56524a7f2e0092ed3",
+			"revisionTime": "2017-06-22T11:17:49Z"
 		},
 		{
-			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
+			"checksumSHA1": "lQfsRf7gWYQDNoI3IOZuwNGUwRo=",
 			"path": "github.com/Financial-Times/service-status-go/buildinfo",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "2rGNLXdRC3qr5n5ll7BpYt8HCK8=",
+			"checksumSHA1": "7QAsTdXi/6nTkDhqKy54YIc69d4=",
 			"path": "github.com/Financial-Times/service-status-go/gtg",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "973POGyMCoyaKQuIYX2f7EKFwlQ=",
+			"checksumSHA1": "YxgjuCI4TJyfQujUeQk3V+gypzo=",
 			"path": "github.com/Financial-Times/service-status-go/httphandlers",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "ZKxETlJdB2XubMrZnXB0FQimVA8=",
+			"checksumSHA1": "s7QDtBhIY9GOfV4gMGlIq/MXuuo=",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "10f801ebc38b33738c9d17d50860f484a0988ff5",
-			"revisionTime": "2017-03-17T14:32:14Z"
+			"revision": "7f976d3a76720c4c27af2ba716b85d2e0a7e38b1",
+			"revisionTime": "2017-07-10T14:32:56Z"
 		},
 		{
-			"checksumSHA1": "OFu4xJEIjiI8Suu+j/gabfp+y6Q=",
+			"checksumSHA1": "DuEyF75v9xaKXfJsCPRdHNOpGZk=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+			"revisionTime": "2017-06-01T20:57:54Z"
 		},
 		{
-			"checksumSHA1": "zmCk+lgIeiOf0Ng9aFP9aFy8ksE=",
+			"checksumSHA1": "IkPM2QLv9urri7S49wzroQx9oXA=",
+			"path": "github.com/gorilla/context",
+			"revision": "08b5f424b9271eedf6f9f0ce86cb9396ed337a42",
+			"revisionTime": "2016-08-17T18:46:32Z"
+		},
+		{
+			"checksumSHA1": "qvsEhA+BntKV5nqjCARYL2gLSzo=",
 			"path": "github.com/gorilla/mux",
-			"revision": "599cba5e7b6137d46ddf58fb1765f5d928e69604",
-			"revisionTime": "2017-02-28T22:43:54Z"
+			"revision": "ac112f7d75a0714af1bd86ab17749b31f7809640",
+			"revisionTime": "2017-07-03T15:07:09Z"
 		},
 		{
-			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
+			"checksumSHA1": "KJqRW8jfPoHquMAd6FI7x92JxFs=",
 			"path": "github.com/hashicorp/go-version",
 			"revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
 			"revisionTime": "2017-02-02T08:07:59Z"
 		},
 		{
-			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
+			"checksumSHA1": "CRYmanmmriS4QPTxS4mM9KhcZI0=",
 			"path": "github.com/jawher/mow.cli",
-			"revision": "d3ffbc2f98b83e09dc8efd55ecec75eb5fd656ec",
-			"revisionTime": "2017-02-20T22:51:54Z"
+			"revision": "8327d12beb75e6471b7f045588acc318d1147146",
+			"revisionTime": "2017-04-30T13:52:12Z"
 		},
 		{
-			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
+			"checksumSHA1": "+oyIJwPyeof36XCkY8awrNfxaNM=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+			"revisionTime": "2017-06-01T20:57:54Z"
 		},
 		{
-			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
+			"checksumSHA1": "HUXE+Nrcau8FSaVEvPYHMvDjxOE=",
 			"path": "github.com/satori/go.uuid",
 			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
 			"revisionTime": "2017-03-21T23:07:31Z"
 		},
 		{
-			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
+			"checksumSHA1": "iDI3Ec9Co5dn9MAf6VRg5cGNRPI=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/stretchr/objx",
 			"path": "github.com/stretchr/objx",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+			"revisionTime": "2017-06-01T20:57:54Z"
 		},
 		{
-			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",
+			"checksumSHA1": "A4Px2X/a0JBJfecp+vMiXE8IWFQ=",
 			"path": "github.com/stretchr/testify/assert",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+			"revisionTime": "2017-06-01T20:57:54Z"
 		},
 		{
-			"checksumSHA1": "WGwMB6WljaeGKzuNCX5M4E8LADE=",
+			"checksumSHA1": "q+MPhXUlpfmP5UgmOySPeldXwvs=",
 			"path": "github.com/stretchr/testify/mock",
-			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
-			"revisionTime": "2017-01-30T11:31:45Z"
+			"revision": "f6abca593680b2315d2075e0f5e2a9751e3f431a",
+			"revisionTime": "2017-06-01T20:57:54Z"
 		},
 		{
 			"checksumSHA1": "oS0UZOGWVVsVciOQ8nZJ582mFF8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,106 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "FUhczVSvt/VQAlWfzATo1YLez2E=",
+			"path": "github.com/Financial-Times/go-fthealth/v1a",
+			"revision": "bc27ed19189994eef0364e4a07879d5a3f3be76f",
+			"revisionTime": "2017-03-24T12:21:32Z"
+		},
+		{
+			"checksumSHA1": "/kMYtkcxWV4dZNvJaEGkDUwt3TA=",
+			"path": "github.com/Financial-Times/message-queue-gonsumer/consumer",
+			"revision": "4e173298922ba4c10721b1b5b3e0d35be7f162e9",
+			"revisionTime": "2017-03-20T10:34:32Z"
+		},
+		{
+			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
+			"path": "github.com/Financial-Times/service-status-go/buildinfo",
+			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
+			"revisionTime": "2016-03-23T11:15:42Z"
+		},
+		{
+			"checksumSHA1": "2rGNLXdRC3qr5n5ll7BpYt8HCK8=",
+			"path": "github.com/Financial-Times/service-status-go/gtg",
+			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
+			"revisionTime": "2016-03-23T11:15:42Z"
+		},
+		{
+			"checksumSHA1": "973POGyMCoyaKQuIYX2f7EKFwlQ=",
+			"path": "github.com/Financial-Times/service-status-go/httphandlers",
+			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
+			"revisionTime": "2016-03-23T11:15:42Z"
+		},
+		{
+			"checksumSHA1": "ZKxETlJdB2XubMrZnXB0FQimVA8=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "10f801ebc38b33738c9d17d50860f484a0988ff5",
+			"revisionTime": "2017-03-17T14:32:14Z"
+		},
+		{
+			"checksumSHA1": "OFu4xJEIjiI8Suu+j/gabfp+y6Q=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "zmCk+lgIeiOf0Ng9aFP9aFy8ksE=",
+			"path": "github.com/gorilla/mux",
+			"revision": "599cba5e7b6137d46ddf58fb1765f5d928e69604",
+			"revisionTime": "2017-02-28T22:43:54Z"
+		},
+		{
+			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
+			"path": "github.com/hashicorp/go-version",
+			"revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
+			"revisionTime": "2017-02-02T08:07:59Z"
+		},
+		{
+			"checksumSHA1": "pYoO37aSFZl2uJAXpePBDnGItZc=",
+			"path": "github.com/jawher/mow.cli",
+			"revision": "d3ffbc2f98b83e09dc8efd55ecec75eb5fd656ec",
+			"revisionTime": "2017-02-20T22:51:54Z"
+		},
+		{
+			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
+			"revisionTime": "2017-03-21T23:07:31Z"
+		},
+		{
+			"checksumSHA1": "EO+jcRet/AJ6IY3lBO8l8BLsZWg=",
+			"origin": "github.com/stretchr/testify/vendor/github.com/stretchr/objx",
+			"path": "github.com/stretchr/objx",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "JXUVA1jky8ZX8w09p2t5KLs97Nc=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "WGwMB6WljaeGKzuNCX5M4E8LADE=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "4d4bfba8f1d1027c4fdbe371823030df51419987",
+			"revisionTime": "2017-01-30T11:31:45Z"
+		},
+		{
+			"checksumSHA1": "oS0UZOGWVVsVciOQ8nZJ582mFF8=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "9ccfe848b9db8435a24c424abbc07a921adf1df5",
+			"revisionTime": "2017-04-27T03:54:25Z"
+		}
+	],
+	"rootPath": "github.com/Financial-Times/notifications-push"
+}


### PR DESCRIPTION
As part of productionize Notifications Push work, we are introducing validation for apiKeys via Mashery call.
Please see https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/productionising-notifications-push-api for architecture diagram and specifications.

Changes in this PR:
 - added vendoring
 - added HTTP call to Mashery to validate apiKey
 - updated Dockerfile