### PR TITLE
Filter notifications by content type - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export NOTIFICATIONS_RESOURCE=content \
     && export TOPIC=PostPublicationEvents \
     && export NOTIFICATIONS_DELAY=10 \
     && export API_BASE_URL="http://api.ft.com" \
-    && export WHITELIST="^http://(methode|wordpress|content)-(article|collection)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$" \
+    && export WHITELIST="^http://(methode|wordpress|content)-(article|collection|content-placeholder)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$" \
     && ./notifications-push
 ```
 
@@ -55,7 +55,7 @@ export NOTIFICATIONS_RESOURCE=content \
     --notifications_delay=10 \
     --api-base-url="http://api.ft.com" \
     --api_key_validation_endpoint="t800/a" \
-    --whitelist="^http://(methode|wordpress|content)-(article|collection)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$"
+    --whitelist="^http://(methode|wordpress|content)-(article|collection|content-placeholder)-(transformer|mapper|unfolder)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content)/[\\w-]+.*$"
 ```
 
 NB: for the complete list of options run `./notifications-push -h`
@@ -63,6 +63,12 @@ NB: for the complete list of options run `./notifications-push -h`
 HTTP endpoints
 ----------
 ```curl -i --header "x-api-key: «api_key»" https://api.ft.com/content/notifications-push```
+
+The following content types could be also specified for which the client would like to receive notifications by setting a "type" parameter on the request: `Article`, `ContentPackage`, `MediaResource`, `Video`, `Image`, `Graphic`, `ImageSet` and `All` to include everything.
+If not specified, by default `Article` is used. If an invalid type is requested an HTTP 400 Bad Request is returned.
+
+E.g.
+```curl -i --header "x-api-key: «api_key»" https://api.ft.com/content/notifications-push?type=Article```
 
 ### Push stream
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ HTTP endpoints
 ----------
 ```curl -i --header "x-api-key: «api_key»" https://api.ft.com/content/notifications-push```
 
-The following content types could be also specified for which the client would like to receive notifications by setting a "type" parameter on the request: `Article`, `ContentPackage`, `MediaResource`, `Video`, `Image`, `Graphic`, `ImageSet` and `All` to include everything.
+The following content types could be also specified for which the client would like to receive notifications by setting a "type" parameter on the request: `Article`, `ContentPackage` and `All` to include everything (also CPHs).
 If not specified, by default `Article` is used. If an invalid type is requested an HTTP 400 Bad Request is returned.
 
 E.g.

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -124,7 +124,7 @@ func (d *dispatcher) Register(subscriber Subscriber) {
 	defer d.lock.Unlock()
 
 	d.subscribers[subscriber] = struct{}{}
-	log.WithField("subscriber", subscriber.Address()).WithField("subscriberType", reflect.TypeOf(subscriber).Elem().Name()).Info("Registered new subscriber")
+	log.WithField("subscriber", subscriber.Address()).WithField("subscriberType", reflect.TypeOf(subscriber).Elem().Name()).WithField("acceptedContentType", subscriber.AcceptedContentType()).Info("Registered new subscriber")
 
 	subscriber.writeOnMsgChannel(heartbeatMsg)
 }

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/fleet/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -90,16 +90,13 @@ func TestShouldDispatchNotificationsToSubscribersByType(t *testing.T) {
 	d.Send(n1, n2)
 
 	actualhbMessage := <-s.NotificationChannel()
-	log.Infof("actualhbMessage: %v", actualhbMessage)
 	assert.Equal(t, heartbeatMsg, actualhbMessage, "First message is a heartbeat")
 
 	actualN2StdMsg := <-s.NotificationChannel()
-	log.Infof("actualN2StdMsg: %v", actualN2StdMsg)
 	verifyNotificationResponse(t, n2, zeroTime, zeroTime, actualN2StdMsg)
 
 	anotherHbMsg := <-s.NotificationChannel()
-	log.Infof("anotherHbMsg: %v", anotherHbMsg)
-	assert.Equal(t, heartbeatMsg, actualhbMessage, "Third message is a heartbeat")
+	assert.Equal(t, heartbeatMsg, anotherHbMsg, "Third message is a heartbeat")
 
 	actualhbMessage = <-m.NotificationChannel()
 	assert.Equal(t, heartbeatMsg, actualhbMessage, "First message is a heartbeat")

--- a/dispatcher/subscribers.go
+++ b/dispatcher/subscribers.go
@@ -18,6 +18,7 @@ type Subscriber interface {
 	writeOnMsgChannel(string)
 	Address() string
 	Since() time.Time
+	AcceptedContentType() string
 }
 
 // StandardSubscriber implements a standard subscriber
@@ -42,6 +43,11 @@ func NewStandardSubscriber(address string, contentType string) Subscriber {
 // Address returns the IP address of the standard subscriber
 func (s *standardSubscriber) Address() string {
 	return s.addr
+}
+
+// AcceptedContentType returns the accepted content type for which notifications are returned
+func (s *standardSubscriber) AcceptedContentType() string {
+	return s.acceptedContentType
 }
 
 // Since returns the time since a subscriber have been registered

--- a/resources/push.go
+++ b/resources/push.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Financial-Times/notifications-push/dispatcher"
 	log "github.com/Sirupsen/logrus"
+	"fmt"
 )
 
 const (
@@ -16,7 +17,7 @@ const (
 	defaultContentType = "Article"
 )
 
-var supportedContentTypes = []string{"Article", "ContentPackage", "All"}
+var supportedContentTypes = []string{"Article", "ContentPackage", "MediaResource", "Video", "Image", "Graphic", "ImageSet", "All"}
 
 //ApiKey is provided either as a request param or as a header.
 func getApiKey(r *http.Request) string {
@@ -51,7 +52,12 @@ func Push(reg dispatcher.Registrar, masheryApiKeyValidationURL string, httpClien
 
 		bw := bufio.NewWriter(w)
 
-		contentTypeParam := resolveContentType(r)
+		contentTypeParam, err := resolveContentType(r)
+		if err != nil {
+			log.WithError(err).Error("Invalid content type")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		monitorParam := r.URL.Query().Get("monitor")
 		isMonitor, _ := strconv.ParseBool(monitorParam)
 
@@ -99,12 +105,15 @@ func getClientAddr(r *http.Request) string {
 	return r.RemoteAddr
 }
 
-func resolveContentType(r *http.Request) string {
+func resolveContentType(r *http.Request) (string, error) {
 	contentType := r.URL.Query().Get("type")
+	if contentType == "" {
+		return defaultContentType, nil
+	}
 	for _, t := range supportedContentTypes {
 		if strings.ToLower(contentType) == strings.ToLower(t) {
-			return contentType
+			return contentType, nil
 		}
 	}
-	return defaultContentType
+	return "", fmt.Errorf("The specified type (%s) is unsupported", contentType)
 }

--- a/resources/push.go
+++ b/resources/push.go
@@ -17,7 +17,7 @@ const (
 	defaultContentType = "Article"
 )
 
-var supportedContentTypes = []string{"Article", "ContentPackage", "MediaResource", "Video", "Image", "Graphic", "ImageSet", "All"}
+var supportedContentTypes = []string{"Article", "ContentPackage", "All"}
 
 //ApiKey is provided either as a request param or as a header.
 func getApiKey(r *http.Request) string {

--- a/resources/push.go
+++ b/resources/push.go
@@ -16,7 +16,7 @@ const (
 	defaultContentType = "Article"
 )
 
-var supportedContentTypes = []string{"Article", "Content", "ContentPackage", "All"}
+var supportedContentTypes = []string{"Article", "ContentPackage", "All"}
 
 //ApiKey is provided either as a request param or as a header.
 func getApiKey(r *http.Request) string {

--- a/resources/push_test.go
+++ b/resources/push_test.go
@@ -123,6 +123,42 @@ func TestPushFailed(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
+func TestPushInvalidType(t *testing.T) {
+	d := new(MockDispatcher)
+	d.On("Register", mock.AnythingOfType("*dispatcher.standardSubscriber")).Return()
+	d.On("Close", mock.AnythingOfType("*dispatcher.standardSubscriber")).Return()
+
+	w := NewStreamResponseRecorder()
+	req, err := http.NewRequest("GET", "/content/notifications-push?type=InvalidType", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header.Set("X-Forwarded-For", "some-host, some-other-host-that-isnt-used")
+	req.Header.Set(apiKeyHeaderField, "some-api-key")
+
+	start = func(sub dispatcher.Subscriber) {
+		sub.NotificationChannel() <- "hi"
+		time.Sleep(10 * time.Millisecond)
+		w.closer <- true
+
+		assert.True(t, time.Now().After(sub.Since()))
+		assert.Equal(t, "some-host", sub.Address())
+	}
+
+	httpClient := initializeMockHTTPClient(&mockTransport{
+		responseStatusCode: http.StatusOK,
+	})
+	Push(d, "http://dummy.ft.com", httpClient)(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	reader := bufio.NewReader(w.Body)
+	body, _ := reader.ReadString(byte(rune(0))) // read to EOF
+
+	assert.True(t, strings.Contains(body, "The specified type (InvalidType) is unsupported"))
+}
+
 func TestMasheryDown(t *testing.T) {
 	d := new(MockDispatcher)
 

--- a/resources/push_test.go
+++ b/resources/push_test.go
@@ -55,7 +55,7 @@ func TestPushStandardSubscriber(t *testing.T) {
 	assert.Equal(t, "0", w.Header().Get("Expires"))
 
 	reader := bufio.NewReader(w.Body)
-	body, _ := reader.ReadString(byte(rune(0))) // read to EOF
+	body, _ := reader.ReadString(byte(0)) // read to EOF
 
 	assert.Equal(t, "data: hi\n\n", body)
 
@@ -99,7 +99,7 @@ func TestPushMonitorSubscriber(t *testing.T) {
 	assert.Equal(t, "0", w.Header().Get("Expires"))
 
 	reader := bufio.NewReader(w.Body)
-	body, _ := reader.ReadString(byte(rune(0))) // read to EOF
+	body, _ := reader.ReadString(byte(0)) // read to EOF
 
 	assert.Equal(t, "data: hi\n\n", body)
 
@@ -154,7 +154,7 @@ func TestPushInvalidType(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 
 	reader := bufio.NewReader(w.Body)
-	body, _ := reader.ReadString(byte(rune(0))) // read to EOF
+	body, _ := reader.ReadString(byte(0)) // read to EOF
 
 	assert.True(t, strings.Contains(body, "The specified type (InvalidType) is unsupported"))
 }


### PR DESCRIPTION
Supported types are "Article", "ContentPackage"and "All" which includes CPHs as well.
Also returning client error (400) for unsupported types.