### PR TITLE
Adjustment for Content placeholders for Wordpress

### DIFF
--- a/consumer/mapper.go
+++ b/consumer/mapper.go
@@ -24,7 +24,7 @@ func (n NotificationMapper) MapNotification(event PublicationEvent, transactionI
 	}
 
 	var eventType string
-	var scoop bool
+	var standout *dispatcher.Standout
 	var title = ""
 	var contentType = ""
 
@@ -34,9 +34,11 @@ func (n NotificationMapper) MapNotification(event PublicationEvent, transactionI
 		eventType = "UPDATE"
 		notificationPayloadMap, ok := event.Payload.(map[string]interface{})
 		if ok {
-			title = getValueFromPayload("title", notificationPayloadMap)
 			contentType = getValueFromPayload("type", notificationPayloadMap)
-			scoop = getScoopFromPayload(notificationPayloadMap)
+			if contentType != "Content" {
+				title = getValueFromPayload("title", notificationPayloadMap)
+				standout = &dispatcher.Standout{Scoop: getScoopFromPayload(notificationPayloadMap)}
+			}
 		}
 	}
 
@@ -47,7 +49,7 @@ func (n NotificationMapper) MapNotification(event PublicationEvent, transactionI
 		PublishReference: transactionID,
 		LastModified:     event.LastModified,
 		Title:            title,
-		Standout:         dispatcher.Standout{Scoop: scoop},
+		Standout:		  standout,
 		ContentType:      contentType,
 	}, nil
 }

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -31,6 +31,30 @@ func TestMapToUpdateNotification(t *testing.T) {
 	assert.Equal(t, "Article", n.ContentType, "ContentType field should be mapped correctly")
 }
 
+func TestMapToUpdateContentNotification(t *testing.T) {
+	standout := map[string]interface{}{"scoop": true}
+	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Content"}
+
+	event := PublicationEvent{
+		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + uuid.NewV4().String(),
+		LastModified: "2016-11-02T10:54:22.234Z",
+		Payload:      payload,
+	}
+
+	mapper := NotificationMapper{
+		APIBaseURL: "test.api.ft.com",
+		Resource:   "list",
+	}
+
+	n, err := mapper.MapNotification(event, "tid_test1")
+
+	assert.Nil(t, err, "The mapping should not return an error")
+	assert.Equal(t, "http://www.ft.com/thing/ThingChangeType/UPDATE", n.Type, "It is an UPDATE notification")
+	assert.Equal(t, "", n.Title, "Title should be nil for Content")
+	assert.Nil(t, n.Standout, "Scoop should be nil for Content")
+	assert.Equal(t, "Content", n.ContentType, "ContentType field should be mapped correctly")
+}
+
 func TestMapToUpdateNotification_ForContentWithVersion3UUID(t *testing.T) {
 	payload := struct{ Foo string }{"bar"}
 

--- a/dispatcher/notifications.go
+++ b/dispatcher/notifications.go
@@ -9,7 +9,7 @@ type Notification struct {
 	LastModified     string   `json:"lastModified,omitempty"`
 	NotificationDate string   `json:"notificationDate,omitempty"`
 	Title            string   `json:"title,omitempty"`
-	Standout         Standout `json:"standout"`
+	Standout         *Standout `json:"standout"`
 	ContentType      string   `json:"-"`
 }
 


### PR DESCRIPTION
Title and standout will be populated only for types that are not Content, so Article and ContentPackage.

https://trello.com/c/wdCp9dsc/130-content-placeholders-for-wordpress-content