### PR TITLE
Fix k8s group name

### DIFF
--- a/helm/notifications-push/app-configs/list-notifications-push_delivery.yaml
+++ b/helm/notifications-push/app-configs/list-notifications-push_delivery.yaml
@@ -3,7 +3,6 @@ replicaCount: 2
 service:
   name: list-notifications-push
 env:
-  GROUP_ID: "k8s-list-notifications-push"
   TOPIC: "PostPublicationEvents"
   CONSUMER_BACKOFF: "2"
   NOTIFICATIONS_RESOURCE: "lists"

--- a/helm/notifications-push/app-configs/notifications-push_delivery.yaml
+++ b/helm/notifications-push/app-configs/notifications-push_delivery.yaml
@@ -3,7 +3,6 @@ replicaCount: 2
 service:
   name: notifications-push
 env:
-  GROUP_ID: "k8s-notifications-push"
   TOPIC: "PostPublicationEvents"
   CONSUMER_BACKOFF: "2"
   NOTIFICATIONS_RESOURCE: "content"

--- a/helm/notifications-push/templates/deployment.yaml
+++ b/helm/notifications-push/templates/deployment.yaml
@@ -34,7 +34,9 @@ spec:
               name: global-config
               key: api.host.with.protocol
         - name: GROUP_ID
-          value: {{ .Values.env.GROUP_ID }}
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: TOPIC
           value: {{ .Values.env.TOPIC }}
         - name: NOTIFICATIONS_DELAY

--- a/helm/notifications-push/templates/deployment.yaml
+++ b/helm/notifications-push/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
               name: global-config
               key: api.host.with.protocol
         - name: GROUP_ID
+          # set this as the pod name so it's unique per instance
           valueFrom:
             fieldRef:
               fieldPath: metadata.name


### PR DESCRIPTION
- make the kafka group name unique per pod by using the pod name as the group name