### PR TITLE
Set as non-resilient

### DIFF
--- a/helm/notifications-push/templates/service.yaml
+++ b/helm/notifications-push/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: {{.Values.env.PUSH_PORT}}

--- a/helm/notifications-push/values.yaml
+++ b/helm/notifications-push/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/notifications-push


### PR DESCRIPTION
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
