### PR TITLE
Adjust allowed content types

### DIFF
--- a/consumer/content.go
+++ b/consumer/content.go
@@ -96,7 +96,7 @@ func (qHandler *ContentQueueHandler) HandleMessage(queueMsg kafka.FTMessage) err
 	}
 	notification.IsE2ETest = isE2ETest
 
-	qHandler.log.WithField("resource", notification.APIURL).WithField("transaction_id", notification.PublishReference).Info("Valid notification received")
+	monitoringLogger.WithField("resource", notification.APIURL).WithField("transaction_id", notification.PublishReference).Info("Valid notification received")
 	qHandler.dispatcher.Send(notification)
 
 	return nil

--- a/consumer/mapper.go
+++ b/consumer/mapper.go
@@ -82,15 +82,15 @@ func (n NotificationMapper) MapMetadataNotification(event AnnotationsMessage, tr
 
 func resolveTypeFromMessageHeader(contentTypeHeader string) string {
 	switch contentTypeHeader {
-	case "application/vnd.ft-upp-article+json":
+	case "application/vnd.ft-upp-article-internal+json":
 		return dispatch.ArticleContentType
 	case "application/vnd.ft-upp-content-package+json":
 		return dispatch.ContentPackageType
 	case "application/vnd.ft-upp-audio+json":
 		return dispatch.AudioContentType
-	case "application/vnd.ft-upp-live-blog-post+json":
+	case "application/vnd.ft-upp-live-blog-post-internal+json":
 		return dispatch.LiveBlogPostType
-	case "application/vnd.ft-upp-live-blog-package+json":
+	case "application/vnd.ft-upp-live-blog-package-internal+json":
 		return dispatch.LiveBlogPackageType
 	default:
 		return ""

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -107,7 +107,7 @@ func TestMapToDeleteNotification_ContentTypeHeader(t *testing.T) {
 	event := ContentMessage{
 		ContentURI:        "http://list-transformer-pr-uk-up.svc.ft.com:8080/list/blah/" + id.String(),
 		LastModified:      "2016-11-02T10:54:22.234Z",
-		ContentTypeHeader: "application/vnd.ft-upp-article+json",
+		ContentTypeHeader: "application/vnd.ft-upp-article-internal+json",
 		Payload:           map[string]interface{}{"deleted": true},
 	}
 

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -79,28 +79,6 @@ func TestMapToDeleteNotification(t *testing.T) {
 	assert.Nil(t, err, "The mapping should not return an error")
 }
 
-func TestMapToDeleteNotificationWithDeleteFlag(t *testing.T) {
-	t.Parallel()
-	id, _ := uuid.NewV4()
-	event := ContentMessage{
-		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8080/list/blah/" + id.String(),
-		LastModified: "2016-11-02T10:54:22.234Z",
-		Payload: map[string]interface{}{
-			"deleted": true,
-		},
-	}
-
-	mapper := NotificationMapper{
-		APIBaseURL: "test.api.ft.com",
-		Resource:   "list",
-	}
-
-	n, err := mapper.MapNotification(event, "tid_test1")
-
-	assert.Equal(t, "http://www.ft.com/thing/ThingChangeType/DELETE", n.Type, "It is an DELETE notification")
-	assert.Nil(t, err, "The mapping should not return an error")
-}
-
 func TestMapToDeleteNotification_ContentTypeHeader(t *testing.T) {
 	t.Parallel()
 	id, _ := uuid.NewV4()

--- a/helm/notifications-push/app-configs/notifications-push_eks_delivery.yaml
+++ b/helm/notifications-push/app-configs/notifications-push_eks_delivery.yaml
@@ -8,7 +8,7 @@ env:
   CONSUMER_BACKOFF: "2"
   NOTIFICATIONS_RESOURCE: "content"
   CONTENT_URI_WHITELIST: "^http://(methode|wordpress-article|content|upp)(-collection|-content-placeholder|-notifications-creator)?(-mapper|-unfolder|)(-pr|-iw)?(-uk-.*)?\\.svc\\.ft\\.com(:\\d{2,5})?/(content|complementarycontent)/[\\w-]+.*$"
-  CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-article+json,application/vnd.ft-upp-content-package+json,application/vnd.ft-upp-audio+json,application/vnd.ft-upp-live-blog-post+json,application/vnd.ft-upp-live-blog-package+json"
+  CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-article-internal+json,application/vnd.ft-upp-content-package+json,application/vnd.ft-upp-audio+json,application/vnd.ft-upp-live-blog-post-internal+json,application/vnd.ft-upp-live-blog-package-internal+json"
   WHITELISTED_METADATA_ORIGIN_SYSTEM_HEADERS: "http://cmdb.ft.com/systems/pac, http://cmdb.ft.com/systems/methode-web-pub, http://cmdb.ft.com/systems/next-video-editor"
   ALLOWED_ALL_CONTENT_TYPE: "Article,ContentPackage,Audio,Content"
   PUSH_PORT: "8599"


### PR DESCRIPTION
# Description

## What

`notification-creator` will publish notifications for internal content types where applicable so the allow-listed ones should be adjusted.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2470)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
