### PR TITLE
implement create event notification based on subscriber policy

### DIFF
--- a/consumer/consume.go
+++ b/consumer/consume.go
@@ -11,7 +11,7 @@ type MessageQueueHandler interface {
 }
 
 type notificationDispatcher interface {
-	Send(notification dispatch.Notification)
+	Send(notification dispatch.NotificationModel)
 }
 
 type MessageQueueRouter struct {

--- a/consumer/content.go
+++ b/consumer/content.go
@@ -96,7 +96,11 @@ func (qHandler *ContentQueueHandler) HandleMessage(queueMsg kafka.FTMessage) err
 	}
 	notification.IsE2ETest = isE2ETest
 
-	monitoringLogger.WithField("resource", notification.APIURL).WithField("transaction_id", notification.PublishReference).Info("Valid notification received")
+	qHandler.log.
+		WithField("resource", notification.APIURL).
+		WithField("transaction_id", notification.PublishReference).
+		WithField("notification_type", notification.Type).
+		Info("Valid notification received")
 	qHandler.dispatcher.Send(notification)
 
 	return nil

--- a/consumer/content.go
+++ b/consumer/content.go
@@ -96,9 +96,8 @@ func (qHandler *ContentQueueHandler) HandleMessage(queueMsg kafka.FTMessage) err
 	}
 	notification.IsE2ETest = isE2ETest
 
-	qHandler.log.
+	monitoringLogger.
 		WithField("resource", notification.APIURL).
-		WithField("transaction_id", notification.PublishReference).
 		WithField("notification_type", notification.Type).
 		Info("Valid notification received")
 	qHandler.dispatcher.Send(notification)

--- a/consumer/content_test.go
+++ b/consumer/content_test.go
@@ -80,7 +80,7 @@ func TestSparkCCTWhitelist(t *testing.T) {
 	}
 	l := logger.NewUPPLogger("test", "PANIC")
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, NewSet(), nil, mapper, dispatcher, l)
 
@@ -104,7 +104,7 @@ func TestMonitoringEvents(t *testing.T) {
 	defer h.Reset()
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	typeWhitelist := NewSet()
 	typeWhitelist.Add("valid-type")
@@ -183,7 +183,7 @@ func TestAcceptNotificationBasedOnContentType(t *testing.T) {
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 	l := logger.NewUPPLogger("test", "PANIC")
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(defaultContentURIWhitelist, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -207,7 +207,7 @@ func TestAcceptNotificationBasedOnAudioContentType(t *testing.T) {
 	contentTypeWhitelist.Add("application/vnd.ft-upp-audio+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(defaultContentURIWhitelist, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -231,7 +231,7 @@ func TestDiscardNotificationBasedOnContentType(t *testing.T) {
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -256,7 +256,7 @@ func TestAcceptNotificationBasedOnContentUriWhenContentTypeIsApplicationJson(t *
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -280,7 +280,7 @@ func TestDiscardNotificationBasedOnContentUriWhenContentTypeIsApplicationJson(t 
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -305,7 +305,7 @@ func TestAcceptNotificationBasedOnContentUriWhenContentTypeIsMissing(t *testing.
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -328,7 +328,7 @@ func TestDiscardNotificationBasedOnContentUriWhenContentTypeIsMissing(t *testing
 	contentTypeWhitelist.Add("application/vnd.ft-upp-article+json")
 
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(sparkIncludedWhiteList, contentTypeWhitelist, nil, mapper, dispatcher, l)
 
@@ -369,7 +369,7 @@ func TestHandleMessage(t *testing.T) {
 	}
 	l := logger.NewUPPLogger("test", "PANIC")
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(defaultContentURIWhitelist, NewSet(), nil, mapper, dispatcher, l)
 
@@ -460,7 +460,7 @@ func TestAcceptNotificationBasedOnE2ETransactionID(t *testing.T) {
 	e2eTestUUIDs := []string{"e4d2885f-1140-400b-9407-921e1c7378cd"}
 	l := logger.NewUPPLogger("test", "PANIC")
 	dispatcher := &mocks.Dispatcher{}
-	dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return()
+	dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return()
 
 	handler := NewContentQueueHandler(nil, nil, e2eTestUUIDs, mapper, dispatcher, l)
 

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -12,7 +12,7 @@ func TestMapToUpdateNotification(t *testing.T) {
 	t.Parallel()
 
 	standout := map[string]interface{}{"scoop": true}
-	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Article"}
+	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Article", "publishCount": "2"}
 	id, _ := uuid.NewV4()
 	event := ContentMessage{
 		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + id.String(),
@@ -38,7 +38,7 @@ func TestMapToCreateNotification(t *testing.T) {
 	t.Parallel()
 
 	standout := map[string]interface{}{"scoop": true}
-	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Article", "publishCount": 1}
+	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Article", "publishCount": "1"}
 	id, _ := uuid.NewV4()
 	event := ContentMessage{
 		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + id.String(),
@@ -184,7 +184,7 @@ func TestNotificationMappingMetadata(t *testing.T) {
 	tests := map[string]struct {
 		Event    AnnotationsMessage
 		HasError bool
-		Expected dispatch.Notification
+		Expected dispatch.NotificationModel
 	}{
 		"Success": {
 			Event: AnnotationsMessage{
@@ -192,7 +192,7 @@ func TestNotificationMappingMetadata(t *testing.T) {
 				LastModified: "2019-11-10T14:34:25.209Z",
 				Payload:      &Annotations{ContentID: "d1b430b9-0ce2-4b85-9c7b-5b700e8519fe"},
 			},
-			Expected: dispatch.Notification{
+			Expected: dispatch.NotificationModel{
 				APIURL:           "test.api.ft.com/content/d1b430b9-0ce2-4b85-9c7b-5b700e8519fe",
 				ID:               "http://www.ft.com/thing/d1b430b9-0ce2-4b85-9c7b-5b700e8519fe",
 				Type:             dispatch.AnnotationUpdateType,

--- a/consumer/mapper_test.go
+++ b/consumer/mapper_test.go
@@ -34,6 +34,32 @@ func TestMapToUpdateNotification(t *testing.T) {
 	assert.Equal(t, "Article", n.SubscriptionType, "SubscriptionType field should be mapped correctly")
 }
 
+func TestMapToCreateNotification(t *testing.T) {
+	t.Parallel()
+
+	standout := map[string]interface{}{"scoop": true}
+	payload := map[string]interface{}{"title": "This is a title", "standout": standout, "type": "Article", "publishCount": 1}
+	id, _ := uuid.NewV4()
+	event := ContentMessage{
+		ContentURI:   "http://list-transformer-pr-uk-up.svc.ft.com:8081/list/blah/" + id.String(),
+		LastModified: "2016-11-02T10:54:22.234Z",
+		Payload:      payload,
+	}
+
+	mapper := NotificationMapper{
+		APIBaseURL: "test.api.ft.com",
+		Resource:   "list",
+	}
+
+	n, err := mapper.MapNotification(event, "tid_test1")
+
+	assert.Nil(t, err, "The mapping should not return an error")
+	assert.Equal(t, "http://www.ft.com/thing/ThingChangeType/CREATE", n.Type, "It is an CREATE notification")
+	assert.Equal(t, "This is a title", n.Title, "Title should pe mapped correctly")
+	assert.Equal(t, true, n.Standout.Scoop, "Scoop field should be mapped correctly")
+	assert.Equal(t, "Article", n.SubscriptionType, "SubscriptionType field should be mapped correctly")
+}
+
 func TestMapToUpdateNotification_ForContentWithVersion3UUID(t *testing.T) {
 	t.Parallel()
 

--- a/consumer/metadata_test.go
+++ b/consumer/metadata_test.go
@@ -18,7 +18,7 @@ func TestMetadata(t *testing.T) {
 
 	tests := map[string]struct {
 		mapper      NotificationMapper
-		sendFunc    func(n dispatch.Notification)
+		sendFunc    func(n dispatch.NotificationModel)
 		whitelist   []string
 		msg         kafka.FTMessage
 		expectError bool
@@ -33,7 +33,7 @@ func TestMetadata(t *testing.T) {
 			expectError: true,
 		},
 		"Test Skipping synthetic messages": {
-			sendFunc: func(n dispatch.Notification) {
+			sendFunc: func(n dispatch.NotificationModel) {
 				t.Fatal("Send should not be called.")
 			},
 			msg: kafka.FTMessage{
@@ -44,7 +44,7 @@ func TestMetadata(t *testing.T) {
 			},
 		},
 		"Test Skipping Messages from Unsupported Origins": {
-			sendFunc: func(n dispatch.Notification) {
+			sendFunc: func(n dispatch.NotificationModel) {
 				t.Fatal("Send should not be called.")
 			},
 			msg: kafka.FTMessage{
@@ -57,7 +57,7 @@ func TestMetadata(t *testing.T) {
 			whitelist: []string{"valid-origins"},
 		},
 		"Test Fail to map message": {
-			sendFunc: func(n dispatch.Notification) {
+			sendFunc: func(n dispatch.NotificationModel) {
 				t.Fatal("Send should not be called.")
 			},
 			msg: kafka.FTMessage{
@@ -75,8 +75,8 @@ func TestMetadata(t *testing.T) {
 				APIBaseURL: "test.api.ft.com",
 				Resource:   "content",
 			},
-			sendFunc: func(n dispatch.Notification) {
-				expected := dispatch.Notification{
+			sendFunc: func(n dispatch.NotificationModel) {
+				expected := dispatch.NotificationModel{
 					Type:             "http://www.ft.com/thing/ThingChangeType/ANNOTATIONS_UPDATE",
 					ID:               "http://www.ft.com/thing/fc1d7a28-9506-323f-9558-11beb985e8f7",
 					APIURL:           "test.api.ft.com/content/fc1d7a28-9506-323f-9558-11beb985e8f7",
@@ -102,9 +102,9 @@ func TestMetadata(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			dispatcher := &mocks.Dispatcher{}
-			dispatcher.On("Send", mock.AnythingOfType("dispatch.Notification")).Return().
+			dispatcher.On("Send", mock.AnythingOfType("dispatch.NotificationModel")).Return().
 				Run(func(args mock.Arguments) {
-					arg := args.Get(0).(dispatch.Notification)
+					arg := args.Get(0).(dispatch.NotificationModel)
 					test.sendFunc(arg)
 				})
 			handler := NewMetadataQueueHandler(test.whitelist, test.mapper, dispatcher, l)

--- a/dispatch/dispatcher.go
+++ b/dispatch/dispatcher.go
@@ -19,7 +19,7 @@ const (
 func NewDispatcher(delay time.Duration, history History, log *logger.UPPLogger) *Dispatcher {
 	return &Dispatcher{
 		delay:       delay,
-		inbound:     make(chan Notification),
+		inbound:     make(chan NotificationModel),
 		subscribers: map[NotificationConsumer]struct{}{},
 		lock:        &sync.RWMutex{},
 		history:     history,
@@ -30,7 +30,7 @@ func NewDispatcher(delay time.Duration, history History, log *logger.UPPLogger) 
 
 type Dispatcher struct {
 	delay       time.Duration
-	inbound     chan Notification
+	inbound     chan NotificationModel
 	subscribers map[NotificationConsumer]struct{}
 	lock        *sync.RWMutex
 	history     History
@@ -54,7 +54,7 @@ func (d *Dispatcher) Stop() {
 	d.stopChan <- true
 }
 
-func (d *Dispatcher) Send(n Notification) {
+func (d *Dispatcher) Send(n NotificationModel) {
 	d.log.WithTransactionID(n.PublishReference).Infof("Received notification. Waiting configured delay (%v).", d.delay)
 	go func() {
 		time.Sleep(d.delay)
@@ -74,13 +74,13 @@ func (d *Dispatcher) Subscribers() []Subscriber {
 	return subs
 }
 
-func (d *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, isCreateEventSubscription bool) (Subscriber, error) {
+func (d *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, options []SubscriptionOption) (Subscriber, error) {
 	var s NotificationConsumer
 	var err error
 	if monitoring {
-		s, err = NewMonitorSubscriber(address, subTypes, isCreateEventSubscription)
+		s, err = NewMonitorSubscriber(address, subTypes, options)
 	} else {
-		s, err = NewStandardSubscriber(address, subTypes, isCreateEventSubscription)
+		s, err = NewStandardSubscriber(address, subTypes, options)
 	}
 
 	if err != nil {
@@ -121,7 +121,7 @@ func logWithSubscriber(log *logger.UPPLogger, s Subscriber) *logger.LogEntry {
 	})
 }
 
-func (d *Dispatcher) forwardToSubscribers(notification Notification) {
+func (d *Dispatcher) forwardToSubscribers(notification NotificationModel) {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 
@@ -161,8 +161,8 @@ func (d *Dispatcher) forwardToSubscribers(notification Notification) {
 				continue
 			}
 		}
-		notification = consolidateNotificationType(notification, sub.isSubscribedForCreate())
-		err := sub.Send(notification)
+		nr := CreateNotificationResponse(notification, sub.Options())
+		err := sub.Send(nr)
 		if err != nil {
 			failed++
 			entry.WithError(err).Warn("Failed forwarding to subscriber.")
@@ -174,7 +174,7 @@ func (d *Dispatcher) forwardToSubscribers(notification Notification) {
 }
 
 // matchesSubType matches subscriber's ContentType with the incoming contentType notification.
-func matchesSubType(n Notification, s Subscriber) bool {
+func matchesSubType(n NotificationModel, s Subscriber) bool {
 	subTypes := make(map[string]bool)
 	for _, subType := range s.SubTypes() {
 		subTypes[strings.ToLower(subType)] = true

--- a/dispatch/dispatcher.go
+++ b/dispatch/dispatcher.go
@@ -74,13 +74,13 @@ func (d *Dispatcher) Subscribers() []Subscriber {
 	return subs
 }
 
-func (d *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool) (Subscriber, error) {
+func (d *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, isCreateEventSubscription bool) (Subscriber, error) {
 	var s NotificationConsumer
 	var err error
 	if monitoring {
-		s, err = NewMonitorSubscriber(address, subTypes)
+		s, err = NewMonitorSubscriber(address, subTypes, isCreateEventSubscription)
 	} else {
-		s, err = NewStandardSubscriber(address, subTypes)
+		s, err = NewStandardSubscriber(address, subTypes, isCreateEventSubscription)
 	}
 
 	if err != nil {
@@ -161,7 +161,7 @@ func (d *Dispatcher) forwardToSubscribers(notification Notification) {
 				continue
 			}
 		}
-
+		notification = consolidateNotificationType(notification, sub.isSubscribedForCreate())
 		err := sub.Send(notification)
 		if err != nil {
 			failed++

--- a/dispatch/dispatcher_test.go
+++ b/dispatch/dispatcher_test.go
@@ -23,7 +23,7 @@ var contentSubscribeTypes = []string{"Article", "ContentPackage", "Audio"}
 var delay = 2 * time.Second
 var historySize = 10
 
-var n1 = Notification{
+var n1 = NotificationModel{
 	APIURL:           "http://api.ft.com/content/7998974a-1e97-11e6-b286-cddde55ca122",
 	ID:               "http://www.ft.com/thing/7998974a-1e97-11e6-b286-cddde55ca122",
 	Type:             "http://www.ft.com/thing/ThingChangeType/UPDATE",
@@ -32,7 +32,7 @@ var n1 = Notification{
 	SubscriptionType: "ContentPackage",
 }
 
-var n2 = Notification{
+var n2 = NotificationModel{
 	APIURL:           "http://api.ft.com/content/7998974a-1e97-11e6-b286-cddde55ca122",
 	ID:               "http://www.ft.com/thing/7998974a-1e97-11e6-b286-cddde55ca122",
 	Type:             "http://www.ft.com/thing/ThingChangeType/DELETE",
@@ -40,7 +40,7 @@ var n2 = Notification{
 	LastModified:     "2016-11-02T10:55:24.244Z",
 }
 
-var annNotif = Notification{
+var annNotif = NotificationModel{
 	APIURL:           "http://api.ft.com/content/7998974a-1e97-11e6-b286-cddde55ca122",
 	ID:               "http://www.ft.com/thing/7998974a-1e97-11e6-b286-cddde55ca122",
 	Type:             "http://www.ft.com/thing/ThingChangeType/ANNOTATIONS_UPDATE",
@@ -48,7 +48,7 @@ var annNotif = Notification{
 	SubscriptionType: "Annotations",
 }
 
-var e2eTestNotification = Notification{
+var e2eTestNotification = NotificationModel{
 	APIURL:           "http://api.ft.com/content/e4d2885f-1140-400b-9407-921e1c7378cd",
 	ID:               "http://www.ft.com/thing/e4d2885f-1140-400b-9407-921e1c7378cd",
 	Type:             "http://www.ft.com/thing/ThingChangeType/UPDATE",
@@ -57,7 +57,7 @@ var e2eTestNotification = Notification{
 	IsE2ETest:        true,
 }
 
-var createNotification = Notification{
+var createNotification = NotificationModel{
 	APIURL:           "http://api.ft.com/content/e4d2885f-1140-400b-9407-921e1c7378cd",
 	ID:               "http://www.ft.com/thing/e4d2885f-1140-400b-9407-921e1c7378cd",
 	Type:             "http://www.ft.com/thing/ThingChangeType/CREATE",
@@ -67,7 +67,7 @@ var createNotification = Notification{
 }
 
 // Subscribers who did not explicitly opt in for Create notifications will actually get Update notification
-var modifiedCreateNotification = Notification{
+var modifiedCreateNotification = NotificationModel{
 	APIURL:           "http://api.ft.com/content/e4d2885f-1140-400b-9407-921e1c7378cd",
 	ID:               "http://www.ft.com/thing/e4d2885f-1140-400b-9407-921e1c7378cd",
 	Type:             "http://www.ft.com/thing/ThingChangeType/UPDATE",
@@ -85,8 +85,8 @@ func TestShouldDispatchNotificationsToMultipleSubscribers(t *testing.T) {
 	h := NewHistory(historySize)
 	d := NewDispatcher(delay, h, l)
 
-	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, false)
-	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, false)
+	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, []SubscriptionOption{})
+	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, []SubscriptionOption{})
 
 	go d.Start()
 	defer d.Stop()
@@ -121,9 +121,9 @@ func TestShouldDispatchNotificationsToSubscribersByType(t *testing.T) {
 	h := NewHistory(historySize)
 	d := NewDispatcher(delay, h, l)
 
-	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, false)
-	s, _ := d.Subscribe("192.168.1.3", []string{typeArticle}, false, false)
-	annSub, _ := d.Subscribe("192.168.1.4", []string{annotationSubType}, false, false)
+	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, []SubscriptionOption{})
+	s, _ := d.Subscribe("192.168.1.3", []string{typeArticle}, false, []SubscriptionOption{})
+	annSub, _ := d.Subscribe("192.168.1.4", []string{annotationSubType}, false, []SubscriptionOption{})
 
 	go d.Start()
 	defer d.Stop()
@@ -184,8 +184,8 @@ func TestShouldDispatchE2ETestNotificationsToMonitoringSubscribersOnly(t *testin
 	h := NewHistory(historySize)
 	d := NewDispatcher(time.Millisecond, h, l)
 
-	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, false)
-	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, false)
+	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, []SubscriptionOption{})
+	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, []SubscriptionOption{})
 
 	go d.Start()
 	defer d.Stop()
@@ -213,10 +213,10 @@ func TestCreateNotificationIsProperlyDispatchedToSubscribers(t *testing.T) {
 	h := NewHistory(historySize)
 	d := NewDispatcher(time.Millisecond, h, l)
 
-	m1, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, true)
-	s1, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, true)
-	m2, _ := d.Subscribe("192.168.1.4", contentSubscribeTypes, true, false)
-	s2, _ := d.Subscribe("192.168.1.5", contentSubscribeTypes, false, false)
+	m1, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, []SubscriptionOption{CreateEventOption})
+	s1, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, []SubscriptionOption{CreateEventOption})
+	m2, _ := d.Subscribe("192.168.1.4", contentSubscribeTypes, true, []SubscriptionOption{})
+	s2, _ := d.Subscribe("192.168.1.5", contentSubscribeTypes, false, []SubscriptionOption{})
 
 	go d.Start()
 	defer d.Stop()
@@ -256,9 +256,9 @@ func TestAddAndRemoveOfSubscribers(t *testing.T) {
 	h := NewHistory(historySize)
 	d := NewDispatcher(delay, h, l)
 
-	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, false)
+	m, _ := d.Subscribe("192.168.1.2", contentSubscribeTypes, true, []SubscriptionOption{})
 	m = m.(NotificationConsumer)
-	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, false)
+	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, []SubscriptionOption{})
 	s = s.(NotificationConsumer)
 
 	go d.Start()
@@ -288,7 +288,7 @@ func TestDispatchDelay(t *testing.T) {
 	h := NewHistory(historySize)
 	d := NewDispatcher(delay, h, l)
 
-	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, false)
+	s, _ := d.Subscribe("192.168.1.3", contentSubscribeTypes, false, []SubscriptionOption{})
 
 	go d.Start()
 	defer d.Stop()
@@ -324,9 +324,9 @@ func TestDispatchedNotificationsInHistory(t *testing.T) {
 	time.Sleep(time.Duration(delay.Seconds()+1) * time.Second)
 
 	notAfter := time.Now()
-	verifyNotification(t, annNotif, notBefore, notAfter, h.Notifications()[2])
-	verifyNotification(t, n1, notBefore, notAfter, h.Notifications()[1])
-	verifyNotification(t, n2, notBefore, notAfter, h.Notifications()[0])
+	verifyNotificationModel(t, annNotif, notBefore, notAfter, h.Notifications()[2])
+	verifyNotificationModel(t, n1, notBefore, notAfter, h.Notifications()[1])
+	verifyNotificationModel(t, n2, notBefore, notAfter, h.Notifications()[0])
 	assert.Len(t, h.Notifications(), 3, "History contains 3 notifications")
 
 	for i := 0; i < historySize; i++ {
@@ -381,8 +381,8 @@ func TestInternalFailToSendNotifications(t *testing.T) {
 	assert.Equal(t, 1, logOccurrence)
 }
 
-func verifyNotificationResponse(t *testing.T, expected Notification, notBefore time.Time, notAfter time.Time, actualMsg string) {
-	actualNotifications := []Notification{}
+func verifyNotificationResponse(t *testing.T, expected NotificationModel, notBefore time.Time, notAfter time.Time, actualMsg string) {
+	actualNotifications := []NotificationResponse{}
 	_ = json.Unmarshal([]byte(actualMsg), &actualNotifications)
 	require.True(t, len(actualNotifications) > 0)
 	actual := actualNotifications[0]
@@ -390,7 +390,22 @@ func verifyNotificationResponse(t *testing.T, expected Notification, notBefore t
 	verifyNotification(t, expected, notBefore, notAfter, actual)
 }
 
-func verifyNotification(t *testing.T, expected Notification, notBefore time.Time, notAfter time.Time, actual Notification) {
+func verifyNotification(t *testing.T, expected NotificationModel, notBefore time.Time, notAfter time.Time, actual NotificationResponse) {
+	assert.Equal(t, expected.ID, actual.ID, "ID")
+	assert.Equal(t, expected.Type, actual.Type, "Type")
+	assert.Equal(t, expected.APIURL, actual.APIURL, "APIURL")
+
+	if actual.LastModified != "" {
+		assert.Equal(t, expected.LastModified, actual.LastModified, "LastModified")
+		assert.Equal(t, expected.PublishReference, actual.PublishReference, "PublishReference")
+
+		actualDate, _ := time.Parse(RFC3339Millis, actual.NotificationDate)
+		assert.False(t, actualDate.Before(notBefore), "notificationDate is too early")
+		assert.False(t, actualDate.After(notAfter), "notificationDate is too late")
+	}
+}
+
+func verifyNotificationModel(t *testing.T, expected NotificationModel, notBefore time.Time, notAfter time.Time, actual NotificationModel) {
 	assert.Equal(t, expected.ID, actual.ID, "ID")
 	assert.Equal(t, expected.Type, actual.Type, "Type")
 	assert.Equal(t, expected.APIURL, actual.APIURL, "APIURL")
@@ -408,13 +423,13 @@ func verifyNotification(t *testing.T, expected Notification, notBefore time.Time
 func TestMatchesSubType(t *testing.T) {
 	tests := []struct {
 		name string
-		n    Notification
+		n    NotificationModel
 		s    *StandardSubscriber
 		res  bool
 	}{
 		{
 			name: "test that notification type matches if subscriber has it as subscription type",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: AudioContentType,
 				Type:             AudioContentType,
 			},
@@ -425,7 +440,7 @@ func TestMatchesSubType(t *testing.T) {
 		},
 		{
 			name: "test that notification type does not match if subscriber does not have it as subscription type",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: AudioContentType,
 				Type:             AudioContentType,
 			},
@@ -436,7 +451,7 @@ func TestMatchesSubType(t *testing.T) {
 		},
 		{
 			name: "test that if notification is of type DELETE and the content type can be resolved - we should match it only if the subscriber has been subscribed for this type",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: AudioContentType,
 				Type:             ContentDeleteType,
 			},
@@ -447,7 +462,7 @@ func TestMatchesSubType(t *testing.T) {
 		},
 		{
 			name: "test if subscriber is subscribed only for annotations and notification is of type DELETE and its content type cannot be resolved - we should NOT match it",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: "",
 				Type:             ContentDeleteType,
 			},
@@ -458,7 +473,7 @@ func TestMatchesSubType(t *testing.T) {
 		},
 		{
 			name: "test if subscriber is not subscribed for annotations and notification is of type DELETE and its content type cannot be resolved - we should match it",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: "",
 				Type:             ContentDeleteType,
 			},
@@ -469,7 +484,7 @@ func TestMatchesSubType(t *testing.T) {
 		},
 		{
 			name: "test if subscriber is subscribed for annotations and another content type AND notification is of type DELETE and its content type cannot be resolved - we should match it",
-			n: Notification{
+			n: NotificationModel{
 				SubscriptionType: "",
 				Type:             ContentDeleteType,
 			},
@@ -497,8 +512,8 @@ type MockSubscriber struct {
 	_dummy int //nolint:unused,structcheck
 }
 
-func (_m *MockSubscriber) isSubscribedForCreate() bool {
-	return false
+func (_m *MockSubscriber) Options() []SubscriptionOption {
+	return []SubscriptionOption{}
 }
 
 // AcceptedSubType provides a mock function with given fields:
@@ -512,7 +527,7 @@ func (_m *MockSubscriber) Address() string {
 }
 
 // send provides a mock function with given fields: n
-func (_m *MockSubscriber) Send(n Notification) error {
+func (_m *MockSubscriber) Send(n NotificationResponse) error {
 	return errors.New("error")
 }
 

--- a/dispatch/history.go
+++ b/dispatch/history.go
@@ -8,22 +8,22 @@ import (
 
 // History contains the last x notifications pushed out to subscribers.
 type History interface {
-	Push(notification Notification)
-	Notifications() []Notification
+	Push(notification NotificationModel)
+	Notifications() []NotificationModel
 }
 
 type inMemoryHistory struct {
 	size          int
 	mutex         *sync.RWMutex
-	notifications []Notification
+	notifications []NotificationModel
 }
 
 // NewHistory creates a new history type
 func NewHistory(size int) History {
-	return &inMemoryHistory{size, &sync.RWMutex{}, []Notification{}}
+	return &inMemoryHistory{size, &sync.RWMutex{}, []NotificationModel{}}
 }
 
-func (i *inMemoryHistory) Push(n Notification) {
+func (i *inMemoryHistory) Push(n NotificationModel) {
 	i.mutex.Lock()
 	defer i.mutex.Unlock()
 
@@ -36,14 +36,14 @@ func (i *inMemoryHistory) Push(n Notification) {
 	}
 }
 
-func (i *inMemoryHistory) Notifications() []Notification {
+func (i *inMemoryHistory) Notifications() []NotificationModel {
 	i.mutex.RLock()
 	defer i.mutex.RUnlock()
 
 	return i.notifications
 }
 
-type byTimestamp []Notification
+type byTimestamp []NotificationModel
 
 func (notifications byTimestamp) Len() int { return len(notifications) }
 

--- a/dispatch/history_test.go
+++ b/dispatch/history_test.go
@@ -13,12 +13,12 @@ func TestHistory(t *testing.T) {
 	history := NewHistory(2)
 	lastModified := time.Now()
 
-	history.Push(Notification{
+	history.Push(NotificationModel{
 		ID:           "note1",
 		LastModified: lastModified.Add(-2 * time.Second).Format(time.RFC3339Nano),
 	})
 
-	history.Push(Notification{
+	history.Push(NotificationModel{
 		ID:           "note2",
 		LastModified: lastModified.Add(-1 * time.Second).Format(time.RFC3339Nano),
 	})
@@ -26,7 +26,7 @@ func TestHistory(t *testing.T) {
 	notifications := history.Notifications()
 	assert.Equal(t, 2, len(notifications), "Should be size 2")
 
-	history.Push(Notification{
+	history.Push(NotificationModel{
 		ID:           "note3",
 		LastModified: lastModified.Format(time.RFC3339Nano),
 	})

--- a/dispatch/notifications.go
+++ b/dispatch/notifications.go
@@ -2,20 +2,22 @@ package dispatch
 
 // subscription types
 const (
-	AnnotationsType        = "Annotations"
-	ArticleContentType     = "Article"
-	ContentPackageType     = "ContentPackage"
-	AudioContentType       = "Audio"
-	LiveBlogPackageType    = "LiveBlogPackage"
-	LiveBlogPostType       = "LiveBlogPost"
-	ContentPlaceholderType = "Content"
-	PageType               = "Page"
-	AllContentType         = "All"
+	AnnotationsType           = "Annotations"
+	ArticleContentType        = "Article"
+	ContentPackageType        = "ContentPackage"
+	AudioContentType          = "Audio"
+	LiveBlogPackageType       = "LiveBlogPackage"
+	LiveBlogPostType          = "LiveBlogPost"
+	ContentPlaceholderType    = "Content"
+	PageType                  = "Page"
+	AllContentType            = "All"
+	CreateEventConsideredType = "INTERNAL_UNSTABLE"
 )
 
 // notification types
 const (
 	ContentUpdateType    = "http://www.ft.com/thing/ThingChangeType/UPDATE"
+	ContentCreateType    = "http://www.ft.com/thing/ThingChangeType/CREATE"
 	ContentDeleteType    = "http://www.ft.com/thing/ThingChangeType/DELETE"
 	AnnotationUpdateType = "http://www.ft.com/thing/ThingChangeType/ANNOTATIONS_UPDATE"
 )
@@ -38,4 +40,25 @@ type Notification struct {
 // Standout model for a Notification
 type Standout struct {
 	Scoop bool `json:"scoop"`
+}
+
+func consolidateNotificationType(notification Notification, isCreateAllowed bool) Notification {
+	notificationType := notification.Type
+	if notificationType == ContentCreateType && !isCreateAllowed {
+		notificationType = ContentUpdateType
+	}
+
+	return Notification{
+		APIURL:           notification.APIURL,
+		ID:               notification.ID,
+		Type:             notificationType,
+		SubscriberID:     notification.SubscriberID,
+		PublishReference: notification.PublishReference,
+		LastModified:     notification.LastModified,
+		NotificationDate: notification.NotificationDate,
+		Title:            notification.Title,
+		Standout:         notification.Standout,
+		SubscriptionType: notification.SubscriptionType,
+		IsE2ETest:        notification.IsE2ETest,
+	}
 }

--- a/dispatch/notifications.go
+++ b/dispatch/notifications.go
@@ -2,16 +2,15 @@ package dispatch
 
 // subscription types
 const (
-	AnnotationsType           = "Annotations"
-	ArticleContentType        = "Article"
-	ContentPackageType        = "ContentPackage"
-	AudioContentType          = "Audio"
-	LiveBlogPackageType       = "LiveBlogPackage"
-	LiveBlogPostType          = "LiveBlogPost"
-	ContentPlaceholderType    = "Content"
-	PageType                  = "Page"
-	AllContentType            = "All"
-	CreateEventConsideredType = "INTERNAL_UNSTABLE"
+	AnnotationsType        = "Annotations"
+	ArticleContentType     = "Article"
+	ContentPackageType     = "ContentPackage"
+	AudioContentType       = "Audio"
+	LiveBlogPackageType    = "LiveBlogPackage"
+	LiveBlogPostType       = "LiveBlogPost"
+	ContentPlaceholderType = "Content"
+	PageType               = "Page"
+	AllContentType         = "All"
 )
 
 // notification types
@@ -22,8 +21,23 @@ const (
 	AnnotationUpdateType = "http://www.ft.com/thing/ThingChangeType/ANNOTATIONS_UPDATE"
 )
 
-// Notification model
-type Notification struct {
+// NotificationModel model
+type NotificationModel struct {
+	APIURL           string
+	ID               string
+	Type             string
+	SubscriberID     string
+	PublishReference string
+	LastModified     string
+	NotificationDate string
+	Title            string
+	Standout         *Standout
+	SubscriptionType string
+	IsE2ETest        bool
+}
+
+// NotificationResponse view
+type NotificationResponse struct {
 	APIURL           string    `json:"apiUrl"`
 	ID               string    `json:"id"`
 	Type             string    `json:"type"`
@@ -33,22 +47,29 @@ type Notification struct {
 	NotificationDate string    `json:"notificationDate,omitempty"`
 	Title            string    `json:"title,omitempty"`
 	Standout         *Standout `json:"standout,omitempty"`
-	SubscriptionType string    `json:"-"`
-	IsE2ETest        bool      `json:"-"`
 }
 
-// Standout model for a Notification
+// Standout model for a NotificationResponse
 type Standout struct {
 	Scoop bool `json:"scoop"`
 }
 
-func consolidateNotificationType(notification Notification, isCreateAllowed bool) Notification {
+func CreateNotificationResponse(notification NotificationModel, subscriberOptions []SubscriptionOption) NotificationResponse {
 	notificationType := notification.Type
-	if notificationType == ContentCreateType && !isCreateAllowed {
+
+	hasCreateEventOption := false
+	for _, o := range subscriberOptions {
+		if o == CreateEventOption {
+			hasCreateEventOption = true
+			break
+		}
+	}
+
+	if notificationType == ContentCreateType && !hasCreateEventOption {
 		notificationType = ContentUpdateType
 	}
 
-	return Notification{
+	return NotificationResponse{
 		APIURL:           notification.APIURL,
 		ID:               notification.ID,
 		Type:             notificationType,
@@ -58,7 +79,5 @@ func consolidateNotificationType(notification Notification, isCreateAllowed bool
 		NotificationDate: notification.NotificationDate,
 		Title:            notification.Title,
 		Standout:         notification.Standout,
-		SubscriptionType: notification.SubscriptionType,
-		IsE2ETest:        notification.IsE2ETest,
 	}
 }

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -46,8 +46,8 @@ func (m *Dispatcher) Subscribers() []dispatch.Subscriber {
 	return args.Get(0).([]dispatch.Subscriber)
 }
 
-func (m *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool) (dispatch.Subscriber, error) {
-	args := m.Called(address, subTypes, monitoring)
+func (m *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, isCreateEventSubscription bool) (dispatch.Subscriber, error) {
+	args := m.Called(address, subTypes, monitoring, isCreateEventSubscription)
 	return args.Get(0).(dispatch.Subscriber), nil
 }
 func (m *Dispatcher) Unsubscribe(s dispatch.Subscriber) {

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -37,7 +37,7 @@ func (m *Dispatcher) Stop() {
 	m.Called()
 }
 
-func (m *Dispatcher) Send(notification dispatch.Notification) {
+func (m *Dispatcher) Send(notification dispatch.NotificationModel) {
 	m.Called(notification)
 }
 
@@ -46,8 +46,8 @@ func (m *Dispatcher) Subscribers() []dispatch.Subscriber {
 	return args.Get(0).([]dispatch.Subscriber)
 }
 
-func (m *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, isCreateEventSubscription bool) (dispatch.Subscriber, error) {
-	args := m.Called(address, subTypes, monitoring, isCreateEventSubscription)
+func (m *Dispatcher) Subscribe(address string, subTypes []string, monitoring bool, options []dispatch.SubscriptionOption) (dispatch.Subscriber, error) {
+	args := m.Called(address, subTypes, monitoring, options)
 	return args.Get(0).(dispatch.Subscriber), nil
 }
 func (m *Dispatcher) Unsubscribe(s dispatch.Subscriber) {

--- a/resources/history.go
+++ b/resources/history.go
@@ -13,7 +13,12 @@ func History(history dispatch.History, log *logger.UPPLogger) func(w http.Respon
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-type", "application/json; charset=UTF-8")
 
-		historyJSON, err := dispatch.MarshalNotificationsJSON(history.Notifications())
+		var notifications []dispatch.NotificationResponse
+		for _, n := range history.Notifications() {
+			notifications = append(notifications, dispatch.CreateNotificationResponse(n, nil))
+		}
+
+		historyJSON, err := dispatch.MarshalNotificationResponsesJSON(notifications)
 		if err != nil {
 			log.WithError(err).Warn(errMsg)
 			http.Error(w, "", http.StatusInternalServerError)

--- a/resources/push.go
+++ b/resources/push.go
@@ -15,25 +15,25 @@ import (
 )
 
 const (
-	HeartbeatMsg            = "[]"
-	apiKeyHeaderField       = "X-Api-Key"
-	apiKeyQueryParam        = "apiKey"
-	apiPolicyField          = "X-API-Policy"
-	ClientAdrKey            = "X-Forwarded-For"
-	defaultSubscriptionType = dispatch.ArticleContentType
+	HeartbeatMsg              = "[]"
+	apiKeyHeaderField         = "X-Api-Key"
+	apiKeyQueryParam          = "apiKey"
+	apiPolicyField            = "X-API-Policy"
+	ClientAdrKey              = "X-Forwarded-For"
+	defaultSubscriptionType   = dispatch.ArticleContentType
+	CreateEventConsideredType = "INTERNAL_UNSTABLE"
 )
 
 var supportedSubscriptionTypes = map[string]bool{
-	strings.ToLower(dispatch.AnnotationsType):           true,
-	strings.ToLower(dispatch.ArticleContentType):        true,
-	strings.ToLower(dispatch.ContentPackageType):        true,
-	strings.ToLower(dispatch.AudioContentType):          true,
-	strings.ToLower(dispatch.AllContentType):            true,
-	strings.ToLower(dispatch.LiveBlogPackageType):       true,
-	strings.ToLower(dispatch.LiveBlogPostType):          true,
-	strings.ToLower(dispatch.ContentPlaceholderType):    true,
-	strings.ToLower(dispatch.PageType):                  true,
-	strings.ToLower(dispatch.CreateEventConsideredType): true,
+	strings.ToLower(dispatch.AnnotationsType):        true,
+	strings.ToLower(dispatch.ArticleContentType):     true,
+	strings.ToLower(dispatch.ContentPackageType):     true,
+	strings.ToLower(dispatch.AudioContentType):       true,
+	strings.ToLower(dispatch.AllContentType):         true,
+	strings.ToLower(dispatch.LiveBlogPackageType):    true,
+	strings.ToLower(dispatch.LiveBlogPostType):       true,
+	strings.ToLower(dispatch.ContentPlaceholderType): true,
+	strings.ToLower(dispatch.PageType):               true,
 }
 
 type keyValidator interface {
@@ -41,7 +41,7 @@ type keyValidator interface {
 }
 
 type notifier interface {
-	Subscribe(address string, subTypes []string, monitoring bool, isCreateEventSubscription bool) (dispatch.Subscriber, error)
+	Subscribe(address string, subTypes []string, monitoring bool, options []dispatch.SubscriptionOption) (dispatch.Subscriber, error)
 	Unsubscribe(subscriber dispatch.Subscriber)
 }
 
@@ -94,9 +94,9 @@ func (h *SubHandler) HandleSubscription(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	isCreateEventsSubscription := false
-	if r.Header.Get(apiPolicyField) == dispatch.CreateEventConsideredType {
-		isCreateEventsSubscription = true
+	subscriptionOptions := []dispatch.SubscriptionOption{}
+	if r.Header.Get(apiPolicyField) == CreateEventConsideredType {
+		subscriptionOptions = append(subscriptionOptions, dispatch.CreateEventOption)
 	}
 
 	subscriptionParams, err := resolveSubType(r, h.contentTypesIncludedInAll)
@@ -108,7 +108,7 @@ func (h *SubHandler) HandleSubscription(w http.ResponseWriter, r *http.Request) 
 	monitorParam := r.URL.Query().Get("monitor")
 	isMonitor, _ := strconv.ParseBool(monitorParam)
 
-	s, err := h.notif.Subscribe(getClientAddr(r), subscriptionParams, isMonitor, isCreateEventsSubscription)
+	s, err := h.notif.Subscribe(getClientAddr(r), subscriptionParams, isMonitor, subscriptionOptions)
 	if err != nil {
 		h.log.WithError(err).Error("Error creating subscription")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -194,11 +194,7 @@ func resolveSubType(r *http.Request, contentTypesIncludedInAll []string) ([]stri
 	values := r.URL.Query()
 	subTypes := values["type"]
 	if len(subTypes) == 0 {
-		if len(retVal) == 0 {
-			return []string{defaultSubscriptionType}, nil
-		}
-		retVal = append(retVal, defaultSubscriptionType)
-		return retVal, nil
+		return []string{defaultSubscriptionType}, nil
 	}
 	// subTypes are being send by the client (subscriber), and needs to be matched with such string value
 	for _, subType := range subTypes {


### PR DESCRIPTION
https://financialtimes.atlassian.net/browse/UPPSF-2473

In order to test the changes you must subscribe for notifications using the following command 

```curl -i --header "x-api-key:<key>" --header "X-API-Policy: INTERNAL_UNSTABLE" https://api-t.ft.com/content/notifications-push?type=All```

and create new content via the cms notifier **(on staging)** including the following property

```
{
    "_internal": {
        "publishCount": 1
    },
...
}
```
this will emit CREATE notitification.
