### PR TITLE
Fix apiUrl mapping for page notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ The following subscription types could be also specified for which the client wo
 * `Audio`
 * `LiveBlogPackage`
 * `LiveBlogPost`
-* `All`- all content changes (Article, ContentPackage, Audio, Content), but not annotation, LiveBlogPackage and LiveBlogPost changes.
+* `Page`  
+* `All`- all content changes (Article, ContentPackage, Audio, Content), but not Annotation, LiveBlogPackage, LiveBlogPost and Page changes.
 * `Annotations` - notifications for manual annotation changes
 
 If not specified, by default `Article` is used. If an invalid type is requested an HTTP 400 Bad Request is returned.
+
+If a policy called `ADVANCED_NOTIFICATIONS` is attached to the API key, then the subscriber will be able to
+distinguish between content creation and updates for the Article, LiveBlogPackage, LiveBlogPost and Content types.
 
 E.g.
 ```curl -i --header "x-api-key: «api_key»" https://api.ft.com/content/notifications-push?type=Article```

--- a/consumer/mapper.go
+++ b/consumer/mapper.go
@@ -30,10 +30,13 @@ func (n NotificationMapper) MapNotification(event ContentMessage, transactionID 
 		return dispatch.NotificationModel{}, errors.New("ContentURI does not contain a UUID")
 	}
 
-	var eventType string
-	var scoop bool
-	var title = ""
-	var contentType = ""
+	var (
+		eventType   string
+		scoop       bool
+		title       string
+		contentType string
+		resource    string
+	)
 
 	notificationPayloadMap, ok := event.Payload.(map[string]interface{})
 	if !ok {
@@ -57,10 +60,15 @@ func (n NotificationMapper) MapNotification(event ContentMessage, transactionID 
 		scoop = getScoopFromPayload(notificationPayloadMap)
 	}
 
+	resource = n.Resource
+	if contentType == dispatch.PageType {
+		resource = "pages"
+	}
+
 	return dispatch.NotificationModel{
 		Type:             eventType,
 		ID:               "http://www.ft.com/thing/" + UUID,
-		APIURL:           n.APIBaseURL + "/" + n.Resource + "/" + UUID,
+		APIURL:           n.APIBaseURL + "/" + resource + "/" + UUID,
 		PublishReference: transactionID,
 		LastModified:     event.LastModified,
 		Title:            title,


### PR DESCRIPTION
# Description

## What

Page notifications require different `apiUrl` mapping.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2614)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
