### PR TITLE
Process API keys on history requests

### DIFF
--- a/app.go
+++ b/app.go
@@ -225,8 +225,9 @@ func main() {
 		if err != nil {
 			log.WithError(err).Fatal("Could not create request handler")
 		}
+		historyHandler := resources.NewHistoryHandler(history, keyProcessor, log)
 
-		initRouter(router, subHandler, *resource, dispatcher, history, hc, log)
+		initRouter(router, subHandler, *resource, dispatcher, historyHandler, hc, log)
 
 		shutdown := startService(srv, dispatcher, kafkaConsumer, queueHandler, log)
 

--- a/app_integration_test.go
+++ b/app_integration_test.go
@@ -112,8 +112,9 @@ func TestPushNotifications(t *testing.T) {
 
 	keyProcessor := resources.NewKeyProcessor(server.URL+apiGatewayValidateURL, server.URL+apiGatewayPoliciesURL, http.DefaultClient, l)
 	s := resources.NewSubHandler(d, keyProcessor, reg, heartbeat, l, []string{"Article", "ContentPackage", "Audio"})
+	historyHandler := resources.NewHistoryHandler(h, keyProcessor, l)
 
-	initRouter(router, s, resource, d, h, hc, l)
+	initRouter(router, s, resource, d, historyHandler, hc, l)
 
 	// key validation
 	router.HandleFunc(apiGatewayValidateURL, func(resp http.ResponseWriter, req *http.Request) {

--- a/push_service.go
+++ b/push_service.go
@@ -52,7 +52,7 @@ func initRouter(r *mux.Router,
 	s *resources.SubHandler,
 	resource string,
 	d *dispatch.Dispatcher,
-	h dispatch.History,
+	h *resources.HistoryHandler,
 	hc *resources.HealthCheck,
 	log *logger.UPPLogger) {
 	r.HandleFunc("/"+resource+"/notifications-push", s.HandleSubscription).Methods("GET")
@@ -63,7 +63,7 @@ func initRouter(r *mux.Router,
 	r.HandleFunc(httphandlers.PingPath, httphandlers.PingHandler)
 
 	r.HandleFunc("/__stats", resources.Stats(d, log)).Methods("GET")
-	r.HandleFunc("/__history", resources.History(h, log)).Methods("GET")
+	r.HandleFunc("/__history", h.History).Methods("GET")
 }
 
 type supervisedConsumer struct {

--- a/resources/history.go
+++ b/resources/history.go
@@ -24,10 +24,6 @@ func NewHistoryHandler(history dispatch.History, keyProcessor KeyProcessor, log 
 
 // History returns history data.
 func (h *HistoryHandler) History(w http.ResponseWriter, r *http.Request) {
-	errMsg := "Serving /__history request"
-
-	w.Header().Set("Content-type", "application/json; charset=UTF-8")
-
 	var subscriptionOptions []dispatch.SubscriptionOption
 
 	// API calls without an API key are supported however if such is present we want
@@ -51,7 +47,7 @@ func (h *HistoryHandler) History(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Validating API key failed", http.StatusInternalServerError)
 			}
 
-			logEntry.Error("Validating API key failed")
+			logEntry.Warn("Validating API key failed")
 			return
 		}
 
@@ -73,7 +69,7 @@ func (h *HistoryHandler) History(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "Extracting API key policies failed", http.StatusInternalServerError)
 			}
 
-			logEntry.Error("Extracting API key x-policies failed")
+			logEntry.Warn("Extracting API key x-policies failed")
 			return
 		}
 
@@ -89,6 +85,10 @@ func (h *HistoryHandler) History(w http.ResponseWriter, r *http.Request) {
 	for _, n := range h.history.Notifications() {
 		notifications = append(notifications, dispatch.CreateNotificationResponse(n, subscriptionOptions))
 	}
+
+	errMsg := "Serving /__history request"
+
+	w.Header().Set("Content-type", "application/json; charset=UTF-8")
 
 	historyJSON, err := dispatch.MarshalNotificationResponsesJSON(notifications)
 	if err != nil {

--- a/resources/history.go
+++ b/resources/history.go
@@ -1,34 +1,105 @@
 package resources
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/Financial-Times/go-logger/v2"
 	"github.com/Financial-Times/notifications-push/v5/dispatch"
 )
 
-// History returns history data
-func History(history dispatch.History, log *logger.UPPLogger) func(w http.ResponseWriter, r *http.Request) {
+type HistoryHandler struct {
+	history      dispatch.History
+	keyProcessor KeyProcessor
+	log          *logger.UPPLogger
+}
+
+func NewHistoryHandler(history dispatch.History, keyProcessor KeyProcessor, log *logger.UPPLogger) *HistoryHandler {
+	return &HistoryHandler{
+		history:      history,
+		keyProcessor: keyProcessor,
+		log:          log,
+	}
+}
+
+// History returns history data.
+func (h *HistoryHandler) History(w http.ResponseWriter, r *http.Request) {
 	errMsg := "Serving /__history request"
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-type", "application/json; charset=UTF-8")
 
-		var notifications []dispatch.NotificationResponse
-		for _, n := range history.Notifications() {
-			notifications = append(notifications, dispatch.CreateNotificationResponse(n, nil))
-		}
+	w.Header().Set("Content-type", "application/json; charset=UTF-8")
 
-		historyJSON, err := dispatch.MarshalNotificationResponsesJSON(notifications)
-		if err != nil {
-			log.WithError(err).Warn(errMsg)
-			http.Error(w, "", http.StatusInternalServerError)
+	var subscriptionOptions []dispatch.SubscriptionOption
+
+	// API calls without an API key are supported however if such is present we want
+	// to deduce whether advanced notifications are requested based on its policies.
+	apiKey := getAPIKey(r)
+	if apiKey != "" {
+		if err := h.keyProcessor.Validate(r.Context(), apiKey); err != nil {
+			logEntry := h.log.WithError(err)
+
+			keyErr := &KeyErr{}
+			if errors.As(err, &keyErr) {
+				if keyErr.KeySuffix != "" {
+					logEntry = logEntry.WithField("apiKeyLastChars", keyErr.KeySuffix)
+				}
+				if keyErr.Description != "" {
+					logEntry = logEntry.WithField("description", keyErr.Description)
+				}
+
+				http.Error(w, keyErr.Msg, keyErr.Status)
+			} else {
+				http.Error(w, "Validating API key failed", http.StatusInternalServerError)
+			}
+
+			logEntry.Error("Validating API key failed")
 			return
 		}
 
-		_, err = w.Write(historyJSON)
+		policies, err := h.keyProcessor.GetPolicies(r.Context(), apiKey)
 		if err != nil {
-			log.WithError(err).Warn(errMsg)
-			http.Error(w, "", http.StatusInternalServerError)
+			logEntry := h.log.WithError(err)
+
+			keyErr := &KeyErr{}
+			if errors.As(err, &keyErr) {
+				if keyErr.KeySuffix != "" {
+					logEntry = logEntry.WithField("apiKeyLastChars", keyErr.KeySuffix)
+				}
+				if keyErr.Description != "" {
+					logEntry = logEntry.WithField("description", keyErr.Description)
+				}
+
+				http.Error(w, keyErr.Msg, keyErr.Status)
+			} else {
+				http.Error(w, "Extracting API key policies failed", http.StatusInternalServerError)
+			}
+
+			logEntry.Error("Extracting API key x-policies failed")
+			return
 		}
+
+		for _, p := range policies {
+			if p == advancedNotificationsXPolicy {
+				subscriptionOptions = append(subscriptionOptions, dispatch.CreateEventOption)
+				break
+			}
+		}
+	}
+
+	var notifications []dispatch.NotificationResponse
+	for _, n := range h.history.Notifications() {
+		notifications = append(notifications, dispatch.CreateNotificationResponse(n, subscriptionOptions))
+	}
+
+	historyJSON, err := dispatch.MarshalNotificationResponsesJSON(notifications)
+	if err != nil {
+		h.log.WithError(err).Warn(errMsg)
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+
+	_, err = w.Write(historyJSON)
+	if err != nil {
+		h.log.WithError(err).Warn(errMsg)
+		http.Error(w, "", http.StatusInternalServerError)
 	}
 }

--- a/resources/history_test.go
+++ b/resources/history_test.go
@@ -1,29 +1,248 @@
 package resources
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/Financial-Times/go-logger/v2"
 	"github.com/Financial-Times/notifications-push/v5/dispatch"
+	"github.com/Financial-Times/notifications-push/v5/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
-func TestHistory(t *testing.T) {
+func TestHistoryHandler(t *testing.T) {
 	t.Parallel()
 
-	l := logger.NewUPPLogger("test", "panic")
-	history := dispatch.NewHistory(1)
+	tests := []struct {
+		name                  string
+		apiKey                string
+		apiKeyProcessor       KeyProcessor
+		notifications         []dispatch.NotificationModel
+		expectedStatusCode    int
+		expectedNotifications []dispatch.NotificationResponse
+		expectedErr           string
+	}{
+		{
+			name:               "Empty history",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name: "Non-empty history",
+			notifications: []dispatch.NotificationModel{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedNotifications: []dispatch.NotificationResponse{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+		},
+		{
+			name:   "History with API key for standard notifications",
+			apiKey: "api-key",
+			apiKeyProcessor: func() KeyProcessor {
+				processor := &mocks.KeyProcessor{}
 
-	req, err := http.NewRequest("GET", "/__history", nil)
-	if err != nil {
-		t.Fatal(err)
+				processor.
+					On("Validate", mock.Anything, "api-key").
+					Return(nil)
+
+				processor.
+					On("GetPolicies", mock.Anything, "api-key").
+					Return([]string{}, nil)
+
+				return processor
+			}(),
+			notifications: []dispatch.NotificationModel{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentCreateType,
+					Title: "Create Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedNotifications: []dispatch.NotificationResponse{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Create Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+		},
+		{
+			name:   "History with API key for advanced notifications",
+			apiKey: "api-key",
+			apiKeyProcessor: func() KeyProcessor {
+				processor := &mocks.KeyProcessor{}
+
+				processor.
+					On("Validate", mock.Anything, "api-key").
+					Return(nil)
+
+				processor.
+					On("GetPolicies", mock.Anything, "api-key").
+					Return([]string{advancedNotificationsXPolicy}, nil)
+
+				return processor
+			}(),
+			notifications: []dispatch.NotificationModel{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentCreateType,
+					Title: "Create Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedNotifications: []dispatch.NotificationResponse{
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentCreateType,
+					Title: "Create Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentUpdateType,
+					Title: "Update Notification",
+				},
+				{
+					ID:    "8ffcc0a0-1334-4325-b4bb-d16dccf597e8",
+					Type:  dispatch.ContentDeleteType,
+					Title: "Delete Notification",
+				},
+			},
+		},
+		{
+			name:   "Invalid API key",
+			apiKey: "api-key",
+			apiKeyProcessor: func() KeyProcessor {
+				processor := &mocks.KeyProcessor{}
+				err := &KeyErr{
+					Msg:    "validation error",
+					Status: http.StatusUnauthorized,
+				}
+
+				processor.
+					On("Validate", mock.Anything, "api-key").
+					Return(err)
+
+				return processor
+			}(),
+			expectedStatusCode: http.StatusUnauthorized,
+			expectedErr:        "validation error\n",
+		},
+		{
+			name:   "Error retrieving API key policies",
+			apiKey: "api-key",
+			apiKeyProcessor: func() KeyProcessor {
+				processor := &mocks.KeyProcessor{}
+				err := &KeyErr{
+					Msg:    "policies error",
+					Status: http.StatusInternalServerError,
+				}
+
+				processor.
+					On("Validate", mock.Anything, "api-key").
+					Return(nil)
+
+				processor.
+					On("GetPolicies", mock.Anything, "api-key").
+					Return(nil, err)
+
+				return processor
+			}(),
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedErr:        "policies error\n",
+		},
 	}
 
-	w := httptest.NewRecorder()
-	History(history, l)(w, req)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			log := logger.NewUPPLogger("TEST", "PANIC")
 
-	assert.Equal(t, "application/json; charset=UTF-8", w.Header().Get("Content-Type"), "Should be json")
-	assert.Equal(t, 200, w.Code, "Should be OK")
+			history := dispatch.NewHistory(len(test.notifications))
+			for _, notification := range test.notifications {
+				history.Push(notification)
+			}
+
+			historyHandler := NewHistoryHandler(history, test.apiKeyProcessor, log)
+
+			req, err := http.NewRequest("GET", "/__history", nil)
+			require.NoError(t, err)
+
+			if test.apiKey != "" {
+				req.Header.Set(apiKeyHeaderField, test.apiKey)
+			}
+
+			w := httptest.NewRecorder()
+			historyHandler.History(w, req)
+
+			assert.Equal(t, test.expectedStatusCode, w.Code)
+
+			body, err := io.ReadAll(w.Body)
+			require.NoError(t, err)
+
+			if test.expectedErr != "" {
+				assert.Equal(t, test.expectedErr, string(body))
+				return
+			}
+
+			var notifications []dispatch.NotificationResponse
+			require.NoError(t, json.Unmarshal(body, &notifications))
+
+			assert.Equal(t, test.expectedNotifications, notifications)
+		})
+	}
+
 }

--- a/resources/key_processor.go
+++ b/resources/key_processor.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Financial-Times/go-logger/v2"
 )
 
-const APIKeyHeaderField = "X-Api-Key"
 const suffixLen = 10
 
 type keyProcessor struct {
@@ -69,7 +68,7 @@ func (p *keyProcessor) Validate(ctx context.Context, key string) error {
 		return NewKeyErrWithDescription("Invalid validation URL", http.StatusInternalServerError, "", err.Error())
 	}
 
-	req.Header.Set(APIKeyHeaderField, key)
+	req.Header.Set(apiKeyHeaderField, key)
 
 	//if the api key has more than five characters we want to log the last five
 	keySuffix := ""
@@ -137,7 +136,7 @@ func (p *keyProcessor) GetPolicies(ctx context.Context, key string) ([]string, e
 		return nil, NewKeyErrWithDescription("Invalid policies URL", http.StatusInternalServerError, "", err.Error())
 	}
 
-	req.Header.Set(APIKeyHeaderField, key)
+	req.Header.Set(apiKeyHeaderField, key)
 
 	// Use the last characters of the key for logging purposes.
 	var keySuffix string

--- a/resources/key_processor_test.go
+++ b/resources/key_processor_test.go
@@ -70,7 +70,7 @@ func TestIsValidApiInvalidValidationGatewayURL(t *testing.T) {
 	assert.Error(t, err, "Validate should fail for invalid key")
 	keyErr := &resources.KeyErr{}
 	assert.True(t, errors.As(err, &keyErr), "Validate should return KeyErr error")
-	assert.Equal(t, "Invalid URL", keyErr.Msg)
+	assert.Equal(t, "Invalid validation URL", keyErr.Msg)
 	assert.Equal(t, http.StatusInternalServerError, keyErr.Status)
 }
 

--- a/resources/push_test.go
+++ b/resources/push_test.go
@@ -140,7 +140,7 @@ func TestSubscription(t *testing.T) {
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodGet, test.Request, nil)
 			req = req.WithContext(ctx)
-			req.Header.Set(APIKeyHeaderField, apiKey)
+			req.Header.Set(apiKeyHeaderField, apiKey)
 			req.Header.Set(ClientAdrKey, subAddress)
 			handler.HandleSubscription(resp, req)
 
@@ -228,7 +228,7 @@ func TestInvalidKey(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/content/notifications-push", nil)
-	req.Header.Set(APIKeyHeaderField, keyAPI)
+	req.Header.Set(apiKeyHeaderField, keyAPI)
 
 	handler.HandleSubscription(resp, req)
 
@@ -267,7 +267,7 @@ func TestHeartbeat(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodGet, "/content/notifications-push", nil)
 	req = req.WithContext(ctx)
-	req.Header.Set(APIKeyHeaderField, keyAPI)
+	req.Header.Set(apiKeyHeaderField, keyAPI)
 	req.Header.Set(ClientAdrKey, subAddress)
 
 	pipe := newPipedResponse()
@@ -341,7 +341,7 @@ func TestPushNotificationDelay(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodGet, "/content/notifications-push", nil)
 	req = req.WithContext(ctx)
-	req.Header.Set(APIKeyHeaderField, keyAPI)
+	req.Header.Set(apiKeyHeaderField, keyAPI)
 	req.Header.Set(ClientAdrKey, subAddress)
 
 	pipe := newPipedResponse()


### PR DESCRIPTION
# Description

## What

Requests to the `/history` endpoint must be able to include API keys.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-2559)

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
