### PR TITLE
Reduce API Gateway GetPolicies call for page and list deployments

### DIFF
--- a/helm/notifications-push/app-configs/list-notifications-push_eks_delivery.yaml
+++ b/helm/notifications-push/app-configs/list-notifications-push_eks_delivery.yaml
@@ -7,7 +7,6 @@ env:
   NOTIFICATIONS_RESOURCE: "lists"
   CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-list+json"
   API_KEY_VALIDATION_ENDPOINT: "push-api-internal/t800/a"
-  API_KEY_POLICIES_ENDPOINT: "push-api-internal/t800/policy"
 
   # We don't want to match any content URIs for this deployment.
   CONTENT_URI_WHITELIST: "$."

--- a/helm/notifications-push/app-configs/page-notifications-push_eks_delivery.yaml
+++ b/helm/notifications-push/app-configs/page-notifications-push_eks_delivery.yaml
@@ -7,7 +7,6 @@ env:
   NOTIFICATIONS_RESOURCE: "pages"
   CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-page+json"
   API_KEY_VALIDATION_ENDPOINT: "push-api-internal/t800/a"
-  API_KEY_POLICIES_ENDPOINT: "push-api-internal/t800/policy"
 
   # We don't want to match any content URIs for this deployment.
   CONTENT_URI_WHITELIST: "$."

--- a/resources/push_test.go
+++ b/resources/push_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -154,7 +155,11 @@ func TestSubscription(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			p.On("Validate", mock.Anything, apiKey).Return(nil)
-			p.On("GetPolicies", mock.Anything, apiKey).Return(test.APIKeyPolicies, nil)
+			if !test.isListHandler && !test.isPagesHandler {
+				os.Setenv("API_KEY_POLICIES_ENDPOINT", "test")
+				defer os.Unsetenv("API_KEY_POLICIES_ENDPOINT")
+				p.On("GetPolicies", mock.Anything, apiKey).Return(test.APIKeyPolicies, nil)
+			}
 
 			if test.ExpectStream {
 				sub, _ := dispatch.NewStandardSubscriber(subAddress, test.ExpectedType, test.SubscriptionOptions)
@@ -215,6 +220,9 @@ func TestPassKeyAsParameter(t *testing.T) {
 	q := req.URL.Query()
 	q.Add(apiKeyQueryParam, keyAPI)
 	req.URL.RawQuery = q.Encode()
+
+	os.Setenv("API_KEY_POLICIES_ENDPOINT", "test")
+	defer os.Unsetenv("API_KEY_POLICIES_ENDPOINT")
 
 	p := &mocks.KeyProcessor{}
 	p.On("Validate", mock.Anything, keyAPI).Return(nil)
@@ -292,6 +300,9 @@ func TestHeartbeat(t *testing.T) {
 	heartbeat := time.Second * 1
 	heartbeatMsg := "data: []\n\n"
 
+	os.Setenv("API_KEY_POLICIES_ENDPOINT", "test")
+	defer os.Unsetenv("API_KEY_POLICIES_ENDPOINT")
+
 	p := &mocks.KeyProcessor{}
 	p.On("Validate", mock.Anything, keyAPI).Return(nil)
 	p.On("GetPolicies", mock.Anything, keyAPI).Return([]string{}, nil)
@@ -360,6 +371,9 @@ func TestPushNotificationDelay(t *testing.T) {
 	heartbeat := time.Second * 1
 	notificationDelay := time.Millisecond * 100
 	heartbeatMsg := "data: []\n\n"
+
+	os.Setenv("API_KEY_POLICIES_ENDPOINT", "test")
+	defer os.Unsetenv("API_KEY_POLICIES_ENDPOINT")
 
 	p := &mocks.KeyProcessor{}
 	p.On("Validate", mock.Anything, keyAPI).Return(nil)


### PR DESCRIPTION
# Description

## What

In order to reduce the API Gateway calls originating from notification-push service, we need to call the GetPolicy API only from content deployment. Calls from page and list deployments are not necessary.

Implementation:
Added a check for environment variable API_KEY_POLICIES_ENDPOINT. If this variable is set, then policy endpoint is called.
Removed the env variable from list and page deployment configs.
Fixed unit tests.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3185  

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

Please check if there is a need for additional unit test that will check the newly added condition for calling policies API

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
