### PR TITLE
Reduce API Gateway GetPolicies call for page and list deployments

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -239,8 +238,7 @@ func main() {
 
 		var keyPoliciesURL *url.URL
 		var policyCheckAllowed bool
-		log.Info(fmt.Sprintf("Fetching the API_KEY_POLICIES_ENDPOINT from helm config %s", *apiKeyPoliciesEndpoint))
-		if apiKeyPoliciesEndpoint != nil {
+		if apiKeyPoliciesEndpoint != nil && *apiKeyPoliciesEndpoint != "" {
 			keyPoliciesURL, err = url.Parse(*apiKeyPoliciesEndpoint)
 			if err != nil {
 				log.WithError(err).Fatal("cannot parse api_key_policies_endpoint")

--- a/app_integration_test.go
+++ b/app_integration_test.go
@@ -106,7 +106,7 @@ func TestPushNotifications(t *testing.T) {
 
 	keyProcessor := resources.NewKeyProcessor(server.URL+apiGatewayValidateURL, server.URL+apiGatewayPoliciesURL, http.DefaultClient, l)
 	s := resources.NewSubHandler(d, keyProcessor, reg, heartbeat, l, []string{"Article", "ContentPackage", "Audio"},
-		[]string{"Annotations", "Article", "ContentPackage", "Audio", "All", "LiveBlogPackage", "LiveBlogPost", "Content"}, "Article")
+		[]string{"Annotations", "Article", "ContentPackage", "Audio", "All", "LiveBlogPackage", "LiveBlogPost", "Content"}, "Article", true)
 
 	initRouter(router, s, resource, d, h, hc, l)
 

--- a/helm/notifications-push/app-configs/list-notifications-push_eks_delivery.yaml
+++ b/helm/notifications-push/app-configs/list-notifications-push_eks_delivery.yaml
@@ -7,7 +7,6 @@ env:
   NOTIFICATIONS_RESOURCE: "lists"
   CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-list+json"
   API_KEY_VALIDATION_ENDPOINT: "push-api-internal/t800/a"
-  API_KEY_POLICIES_ENDPOINT: "push-api-internal/t800/policy"
 
   # We don't want to match any content URIs for this deployment.
   CONTENT_URI_WHITELIST: "$."

--- a/helm/notifications-push/app-configs/page-notifications-push_eks_delivery.yaml
+++ b/helm/notifications-push/app-configs/page-notifications-push_eks_delivery.yaml
@@ -7,7 +7,6 @@ env:
   NOTIFICATIONS_RESOURCE: "pages"
   CONTENT_TYPE_WHITELIST: "application/vnd.ft-upp-page+json"
   API_KEY_VALIDATION_ENDPOINT: "push-api-internal/t800/a"
-  API_KEY_POLICIES_ENDPOINT: "push-api-internal/t800/policy"
 
   # We don't want to match any content URIs for this deployment.
   CONTENT_URI_WHITELIST: "$."

--- a/resources/push.go
+++ b/resources/push.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +46,7 @@ type SubHandler struct {
 	contentTypesIncludedInAll []string
 	contentTypesSupported     []string
 	defaultSubscriptionType   string
+	policyCheckAllowed        bool
 }
 
 func NewSubHandler(n notifier,
@@ -57,6 +57,7 @@ func NewSubHandler(n notifier,
 	contentTypesIncludedInAll []string,
 	contentTypesSupported []string,
 	defaultSubscriptionType string,
+	policyCheckAllowed bool,
 ) *SubHandler {
 	return &SubHandler{
 		notif:                     n,
@@ -67,6 +68,7 @@ func NewSubHandler(n notifier,
 		contentTypesIncludedInAll: contentTypesIncludedInAll,
 		contentTypesSupported:     contentTypesSupported,
 		defaultSubscriptionType:   defaultSubscriptionType,
+		policyCheckAllowed:        policyCheckAllowed,
 	}
 }
 
@@ -90,7 +92,7 @@ func (h *SubHandler) HandleSubscription(w http.ResponseWriter, r *http.Request) 
 	}
 
 	subscriptionOptions := []dispatch.SubscriptionOption{}
-	if _, ok := os.LookupEnv("API_KEY_POLICIES_ENDPOINT"); ok {
+	if h.policyCheckAllowed {
 		policies, err := h.keyProcessor.GetPolicies(r.Context(), apiKey)
 		if err != nil {
 			logEntry := h.log.WithError(err)


### PR DESCRIPTION
# Description

## What

In order to reduce the API Gateway calls originating from notification-push service, we need to call the GetPolicy API only from content deployment. Calls from page and list deployments are not necessary.

Implementation:
Added a check for environment variable API_KEY_POLICIES_ENDPOINT. If this variable is set, then policy endpoint is called.
Removed the env variable from list and page deployment configs.
Fixed unit tests and integration tests.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3185 

## Anything, in particular, you'd like to highlight to reviewers

Please check if there is a need for additional unit test that will check the newly added condition for calling policies API

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
